### PR TITLE
EPP-57 Amend - SEC2 - Create a what is YOUR NAME on the licence page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-### Explosive precursors and poisons
+### Explosives precursors and poisons
 ## TBD

--- a/apps/epp-amend/fields/index.js
+++ b/apps/epp-amend/fields/index.js
@@ -1,3 +1,4 @@
+const title = require('../../../utilities/constants/titles.js');
 const dateComponent = require('hof').components.date;
 
 module.exports = {
@@ -10,6 +11,31 @@ module.exports = {
       { type: 'maxlength', arguments: [16] },
       { type: 'minlength', arguments: [13] }
     ]
+  },
+  'amend-name-title': {
+    mixin: 'select',
+    validate: ['required'],
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input--width-2'],
+    options: [{
+      value: '',
+      label: 'fields.amend-name-title.options.none_selected'
+    }].concat(title)
+  },
+  'amend-firstname': {
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }],
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'amend-middlename': {
+    validate: [{ type: 'maxlength', arguments: [250] }],
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'amend-lastname': {
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }],
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'amend-phone-number': {
     mixin: 'input-text',

--- a/apps/epp-amend/fields/index.js
+++ b/apps/epp-amend/fields/index.js
@@ -28,7 +28,7 @@ module.exports = {
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'amend-middlename': {
-    validate: [{ type: 'maxlength', arguments: [250] }],
+    validate: ['notUrl', { type: 'maxlength', arguments: [250] }],
     labelClassName: 'govuk-label--s',
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },

--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -13,19 +13,19 @@ module.exports = {
       behaviours: [validateAndRedirect, ValidateLicenceNumber],
       backLink: '/application-type',
       fields: ['amend-licence-number'],
-      next: '/amend-name-on-licence',
+      next: '/name-on-licence',
       locals: {captionHeading: 'Section 1 of 20'}
     },
-    '/amend-name-on-licence': {
+    '/name-on-licence': {
       fields: [
         'amend-name-title',
         'amend-firstname',
         'amend-middlename',
         'amend-lastname'
       ],
-      next: '/amend-date-of-birth'
+      next: '/date-of-birth'
     },
-    '/amend-date-of-birth': {
+    '/date-of-birth': {
       fields: ['amend-date-of-birth'],
       next: '/section-four',
       locals: {captionHeading: 'Section 3 of 20'}

--- a/apps/epp-amend/sections/summary-data-sections.js
+++ b/apps/epp-amend/sections/summary-data-sections.js
@@ -1,11 +1,19 @@
 'use strict';
 
 module.exports = {
-  'amend-licence-number': {
+  'Licence details': {
     steps: [
       {
         step: '/licence-number',
         field: 'amend-licence-number'
+      }
+    ]
+  },
+  'amend-name-on-licence': {
+    steps: [
+      {
+        step: '/amend-name-on-licence',
+        fields: ['amend-name-title', 'amend-firstname', 'amend-middlename', 'amend-lastname']
       }
     ]
   },

--- a/apps/epp-amend/sections/summary-data-sections.js
+++ b/apps/epp-amend/sections/summary-data-sections.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  'Licence details': {
+  'amend-licence-number': {
     steps: [
       {
         step: '/licence-number',
@@ -9,11 +9,23 @@ module.exports = {
       }
     ]
   },
-  'amend-name-on-licence': {
+  'applicant-name': {
     steps: [
       {
         step: '/amend-name-on-licence',
-        fields: ['amend-name-title', 'amend-firstname', 'amend-middlename', 'amend-lastname']
+        field: 'amend-name-title'
+      },
+      {
+        step: '/amend-name-on-licence',
+        field: 'amend-firstname'
+      },
+      {
+        step: '/amend-name-on-licence',
+        field: 'amend-middlename'
+      },
+      {
+        step: '/amend-name-on-licence',
+        field: 'amend-lastname'
       }
     ]
   },

--- a/apps/epp-amend/sections/summary-data-sections.js
+++ b/apps/epp-amend/sections/summary-data-sections.js
@@ -1,4 +1,9 @@
 'use strict';
+const config = require('../../../config');
+const dateFormatter = new Intl.DateTimeFormat(
+  config.dateLocales,
+  config.dateFormat
+);
 
 module.exports = {
   'amend-licence-number': {
@@ -12,19 +17,19 @@ module.exports = {
   'applicant-name': {
     steps: [
       {
-        step: '/amend-name-on-licence',
+        step: '/name-on-licence',
         field: 'amend-name-title'
       },
       {
-        step: '/amend-name-on-licence',
+        step: '/name-on-licence',
         field: 'amend-firstname'
       },
       {
-        step: '/amend-name-on-licence',
+        step: '/name-on-licence',
         field: 'amend-middlename'
       },
       {
-        step: '/amend-name-on-licence',
+        step: '/name-on-licence',
         field: 'amend-lastname'
       }
     ]
@@ -45,7 +50,8 @@ module.exports = {
     steps: [
       {
         step: '/date-of-birth',
-        field: 'amend-date-of-birth'
+        field: 'amend-date-of-birth',
+        parse: date => date && dateFormatter.format(new Date(date))
       }
     ]
   }

--- a/apps/epp-amend/translations/src/en/fields.json
+++ b/apps/epp-amend/translations/src/en/fields.json
@@ -2,6 +2,21 @@
   "amend-licence-number": {
         "hint": "For example 95/W/000000/2024"
     },
+  "amend-name-title": {
+    "label": "Title",
+    "options": {
+      "none_selected": "Select"
+    }
+  },
+  "amend-firstname": {
+    "label": "First name"
+  },
+  "amend-middlename": {
+    "label": "Middle names (optional)"
+  },
+  "amend-lastname": {
+    "label": "Last name"
+  },
     "amend-phone-number": {
         "label": "Contact phone number",
         "hint": "For international numbers, include the country code"

--- a/apps/epp-amend/translations/src/en/journey.json
+++ b/apps/epp-amend/translations/src/en/journey.json
@@ -1,5 +1,5 @@
 {
-  "header": "Explosive precursors and poisons licensing",
+  "header": "Explosives precursors and poisons licensing",
   "phase": "beta",
   "serviceName": "Amend an explosives and precursor chemicals licence"
 }

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -21,11 +21,11 @@
       "applicant-name": {
         "header": "Applicant name"
       },
-      "amend-contact-details": {
-        "header": "Contact details"
-      },
       "amend-date-of-birth": {
         "header": "Applicant date of birth"
+      },
+      "amend-contact-details": {
+        "header": "Contact details"
       }
     },
     "fields": {
@@ -44,14 +44,14 @@
       "amend-name-lastname": { 
         "label" : "Surname"
       },
+      "amend-date-of-birth": {
+        "label": "Date of birth"
+      },
       "amend-phone-number": {
         "label": "Contact phone number"
       },
       "amend-email": {
         "label": "Email address"
-      },
-      "amend-date-of-birth": {
-        "label": "Date of birth"
       }
     },
   "application-submitted": {

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -2,13 +2,13 @@
   "licence-number": {
     "header": "Enter your licence number"
   },
-  "amend-name-on-licence": {
+  "name-on-licence": {
     "header": "What is your name on the licence?"
   },
   "contact-details": {
     "header": "What are your contact details?"
   },
-  "amend-date-of-birth": {
+  "date-of-birth": {
     "header": " What is your date of Birth?"
   },
   "confirm": {

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -18,6 +18,9 @@
       "amend-licence-number":{
         "header": "Licence details"
       },
+      "applicant-name": {
+        "header": "Applicant name"
+      },
       "amend-contact-details": {
         "header": "Contact details"
       },
@@ -28,6 +31,18 @@
     "fields": {
       "amend-licence-number": {
         "label": "Licence number"
+      },
+      "amend-name-title": { 
+      "label" : "Title"
+      },
+      "amend-name-firstname": { 
+        "label" : "First name"
+      },
+      "amend-name-middlename": { 
+        "label" : "Middle name(s)"
+      },
+      "amend-name-lastname": { 
+        "label" : "Surname"
       },
       "amend-phone-number": {
         "label": "Contact phone number"

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -2,6 +2,9 @@
   "licence-number": {
     "header": "Enter your licence number"
   },
+  "amend-name-on-licence": {
+    "header": "What is your name on the licence?"
+  },
   "contact-details": {
     "header": "What are your contact details?"
   },

--- a/apps/epp-amend/translations/src/en/validation.json
+++ b/apps/epp-amend/translations/src/en/validation.json
@@ -18,13 +18,16 @@
     },
     "amend-firstname" : {
         "required" : "Enter your first name",
+        "notUrl" : "Your answer must not include a URL",
         "maxlength" : "First name must between 1 and 250 characters"
     },
     "amend-middlename" :{
+        "notUrl" : "Your answer must not include a URL",
          "maxlength" : "Middle names must be between 250 characters or less"
     },
     "amend-lastname" : {
         "required" : "Enter your last name",
+        "notUrl" : "Your answer must not include a URL",
         "maxlength" : "Last name must be between 1 and 250 characters"
     },
     "amend-date-of-birth": {

--- a/apps/epp-amend/translations/src/en/validation.json
+++ b/apps/epp-amend/translations/src/en/validation.json
@@ -13,6 +13,20 @@
         "required": "Enter a contact email address",
         "email": "Enter a real email address"
     },
+    "amend-name-title" : {
+        "required" : "Select your title"
+    },
+    "amend-firstname" : {
+        "required" : "Enter your first name",
+        "maxlength" : "First name must between 1 and 250 characters"
+    },
+    "amend-middlename" :{
+         "maxlength" : "Middle names must be between 250 characters or less"
+    },
+    "amend-lastname" : {
+        "required" : "Enter your last name",
+        "maxlength" : "Last name must be between 1 and 250 characters"
+    },
     "amend-date-of-birth": {
       "required": "Enter your date of birth",
         "date": "Enter a real date",

--- a/config.js
+++ b/config.js
@@ -5,6 +5,12 @@ const env = process.env.NODE_ENV || 'production';
 module.exports = {
   PRETTY_DATE_FORMAT: 'DD MMMM YYYY',
   dateTimeFormat: 'DD MMM YYYY HH:mm:ss',
+  dateLocales: 'en-GB',
+  dateFormat: {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric'
+  },
   env: env,
   email: {
     notifyApiKey: process.env.NOTIFY_KEY,

--- a/hof.settings.json
+++ b/hof.settings.json
@@ -1,5 +1,5 @@
 {
-  "appName": "Explosive precursors and poisons",
+  "appName": "Explosives precursors and poisons",
   "theme": "govUK",
   "behaviours": [
     "hof/components/clear-session"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "explosive-precursors-and-poisons",
+  "name": "explosives-precursors-and-poisons",
   "version": "1.0.0",
-  "description": "Explosive Precursors and Poisons form",
+  "description": "Explosives Precursors and Poisons form",
   "main": "index.js",
   "engines": {
     "node": ">=20.16.0 <21.0.0"


### PR DESCRIPTION
## What? 
Added `what is your name` page in amend path section 2
## Why? 
As per jira ticket [EPP-57](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-57)
## How? 
- add fields in `fields/index.js`, `fields.json`, `page.json`,` validation.json`
- add step and fields in `summary-data-sections.js`
- defined steps in `index.js`

## Testing?
manual test
## Screenshots (optional)
## Anything Else? (optional)
- add some logic to render fields in confirm-summary page
- correct service name "Explosives precursors and poisons"
- add `confirm.html`file,
- update steps and fields in `summary-data-sections.js`
- add fields for the confirm summary page in `pages.json`
- add initial page path for this section in `apps/epp-common/index.js`
- correct date format for `date of birth`

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
