### PR TITLE
EPP-46 New & Renew Create contact detail page

### DIFF
--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -1,1 +1,15 @@
-module.exports = {};
+module.exports = {
+
+  'new-renew-phone-number': {
+    mixin: 'input-text',
+    className: ['govuk-input'],
+    labelClassName: 'govuk-label--m',
+    validate: ['required', 'internationalPhoneNumber']
+  },
+  'new-renew-email': {
+    mixin: 'input-text',
+    className: ['govuk-input'],
+    labelClassName: 'govuk-label--m',
+    validate: ['required', 'email']
+  }
+};

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -110,7 +110,10 @@ module.exports = {
       }
     },
     '/contact-details': {
-      fields: [],
+      fields: [
+        'new-renew-phone-number',
+        'new-renew-email'
+      ],
       next: '/identity-details',
       locals: {
         sectionNo: {

--- a/apps/epp-new/sections/summary-data-sections.js
+++ b/apps/epp-new/sections/summary-data-sections.js
@@ -6,5 +6,17 @@ module.exports = {
       step: '/enter-license-number',
       field: 'new-renew-license-number'
     }
-  ]
+  ],
+  'new-renew-contact-details': {
+    steps: [
+      {
+        steps: '/contact-details',
+        field: 'new-renew-phone-number'
+      },
+      {
+        steps: '/contact-details',
+        field: 'new-renew-email'
+      }
+    ]
+  }
 };

--- a/apps/epp-new/translations/src/en/fields.json
+++ b/apps/epp-new/translations/src/en/fields.json
@@ -1,5 +1,14 @@
 {
   "name": {
     "label": "Full name"
+  },
+  "new-renew-phone-number": {
+    "label": "Contact phone number",
+    "hint": "For international numbers, include the country code"
+  },
+  "new-renew-email": {
+      "label": "Email address",
+      "hint": "Where we will contact you about the outcome of your application"
   }
+
 }

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -11,17 +11,31 @@
     "title":"Other names",
     "header":"Other names"
   },
+  "contact-details": {
+    "title":"What are your contact details?",
+    "header": "What are your contact details?"
+  },
   "confirm": {
     "header": "Check your answers",
-    "submit-warning": "Once you have submitted your application, you will not be able to adjust it. Please check it is correct.",
+    "title": "Check your answers – Apply for an explosives precursors and poisons licence",
+    "submit-warning": "Check your answer before paying and submitting.",
     "sections": {
       "sectionHeader": {
         "header": "Personal Details"
+      },
+      "new-renew-contact-details": {
+        "header": "Contact details"
       }
     },
     "fields":{
       "new-renew-license-number": {
         "label": "Licence number"
+      },
+      "new-renew-phone-number": {
+        "label": "Contact phone number"
+      },
+      "new-renew-email": {
+        "label": "Email address"
       }
     }
   },

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -1,1 +1,10 @@
-{}
+{
+    "new-renew-phone-number": {
+        "required": "Enter your telephone number",
+        "internationalPhoneNumber": "Enter a real telephone number"
+    },
+    "new-renew-email": {
+        "required": "Enter a contact email address",
+        "email": "Enter a real email address"
+    }
+}

--- a/apps/epp-new/views/confirm.html
+++ b/apps/epp-new/views/confirm.html
@@ -1,0 +1,12 @@
+<title>{{#t}}pages.confirm.title{{/t}} - GOV.UK</title>
+{{<partials-page}}
+ {{$page-content}}
+  <div>
+    <p class="govuk-body">{{#t}}pages.confirm.submit-warning{{/t}}</p>
+  </div>
+    {{#rows}}
+      {{> partials-summary-table}}
+    {{/rows}}
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/epp-new/views/partials/summary-table.html
+++ b/apps/epp-new/views/partials/summary-table.html
@@ -1,9 +1,28 @@
 <div>
-    <h1 class="govuk-heading-l">{{section}}</h1>
+    <h2 class="section-header">{{section}}</h2>
   </div>
   <dl>
-      {{#fields}}
-      {{^omitFromSummary}}{{> partials-summary-table-row}}{{/omitFromSummary}}
-      {{/fields}}
-  </dl>
-  
+    {{#fields}}
+    {{^omitFromSummary}}
+      <div class="confirm-row">
+        {{#isSeparator}}
+        {{/isSeparator}}
+        {{^isSeparator}}
+          <dt class="confirm-label">{{label}}</dt>
+          <dd class="confirm-value" data-value="{{value}}">{{value}}</dd>
+        {{^omitChangeLink}}
+          {{#changeLink}}
+            <dd><span><a class="govuk-link" href="{{changeLink}}" id="{{field}}-change-{{index}}">{{#t}}buttons.change{{/t}} <span class="visuallyhidden">{{changeLinkDescription}} from {{value}}</span></a></span></dd>
+          {{/changeLink}}
+          {{^changeLink}}
+            <dd><span><a class="govuk-link" href="{{baseUrl}}{{step}}/edit#{{field}}" id="{{field}}-change">{{#t}}buttons.change{{/t}} <span class="visuallyhidden">{{changeLinkDescription}} from {{value}}</span></a></span></dd>
+          {{/changeLink}}
+        {{/omitChangeLink}}
+        {{#omitChangeLink}}
+          <dd> </dd>
+        {{/omitChangeLink}}
+        {{/isSeparator}}
+      </div>
+    {{/omitFromSummary}}
+    {{/fields}}
+  </dl> 

--- a/apps/epp-renew/translations/src/en/pages.json
+++ b/apps/epp-renew/translations/src/en/pages.json
@@ -3,4 +3,5 @@
     "title": "Enter your licence number",
     "header": "Enter your licence number"
   }
+
 }


### PR DESCRIPTION
## What? 
[EPP-46](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-46) - New & Renew - Create a CONTACT DETAILS page.

## Why? 
To Allow user enter new contact detail

## How? 
- Added Fields for each method of contact in the fields folder and applied the validation control on each fields

- Added title page

- Created a partial page for the confirm summary page then added the values of each fields

- Added page header and content according to figma design.

## Testing?
Tested locally

## Screenshots (optional)


## Anything Else? (optional)
## Check list
<img width="1115" alt="Screenshot 2025-01-02 at 12 00 35" src="https://github.com/user-attachments/assets/0fd4c742-d39a-41d3-8c95-37b2bb68f983" />

<img width="1193" alt="Screenshot 2025-01-02 at 12 02 00" src="https://github.com/user-attachments/assets/0a4dbd3d-7633-46b8-ad08-d1f572d1bf39" />

<img width="1009" alt="Screenshot 2025-01-02 at 12 05 04" src="https://github.com/user-attachments/assets/95336fa9-38d2-4b63-a702-ff13fe2e1c5f" />

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
