### PR TITLE
EPP-166

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -15,7 +15,7 @@ if [[ $1 == 'tear_down' ]]; then
   export DRONE_SOURCE_BRANCH=$(cat /root/.dockersock/branch_name.txt)
 
   $kd --delete -f kube/configmaps/configmap.yml
-  $kd --delete -f kube/redis -f kube/app
+  $kd --delete -f kube/redis -f kube/app -f kube/file-vault
   echo "Torn Down Branch - $APP_NAME-$DRONE_SOURCE_BRANCH.internal.branch.sas-notprod.homeoffice.gov.uk"
   exit 0
 fi


### PR DESCRIPTION
## What? 
We noticed that upon merging the files into uat the file vault deployment hangs back and creates configmap errors (see screenshot)
[EPP-126](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-126)

## What? 
Clear filevault files upon branch deletion.

## Why? 
as per Jira ticket [EPP-126](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-126)

## How? 
- add  $kd --delete -f kube/file-vault in deploy.sh

## Testing?
manual test
## Screenshots (optional)
![image](https://github.com/user-attachments/assets/eba2f8ef-0150-4f01-b5d8-c5b003c3360b)

## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging

