### PR TITLE
EPP-74 new and renew medical declaration page

### DIFF
--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -54,5 +54,9 @@ module.exports = {
     validate: ['required', 'email'],
     className: ['govuk-input'],
     labelClassName: 'govuk-label--m'
+  },
+  'medical-declaration': {
+    mixin: 'checkbox',
+    validate: ['required']
   }
 };

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -245,7 +245,7 @@ module.exports = {
       }
     },
     '/medical-declaration': {
-      fields: [],
+      fields: ['medical-declaration'],
       next: '/medical-history',
       locals: {
         sectionNo: {

--- a/apps/epp-new/sections/summary-data-sections.js
+++ b/apps/epp-new/sections/summary-data-sections.js
@@ -42,5 +42,12 @@ module.exports = {
         field: 'new-renew-email'
       }
     ]
+  },
+  'medical-information': {
+    steps:
+    {
+      step: '/medical-declaration',
+      field: ['medical-declaration']
+    }
   }
 };

--- a/apps/epp-new/translations/src/en/fields.json
+++ b/apps/epp-new/translations/src/en/fields.json
@@ -34,7 +34,10 @@
     "hint": "For international numbers, include the country code"
   },
   "new-renew-email": {
-    "label": "Email address",
-    "hint": "Where we will contact you about the outcome of your application"
-  }
+      "label": "Email address",
+      "hint": "Where we will contact you about the outcome of your application"
+  },
+  "medical-declaration": {
+        "label" : "I have read and agree to this medical declaration"
+    }
 }

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -15,6 +15,14 @@
     "title": "What are your contact details?",
     "header": "What are your contact details?"
   },
+  "medical-declaration": {
+    "header": "Medical declaration",
+    "paragraph1" : "I give permission for the Home Office to contact my doctor (GP or equivalent) and/or specialist to obtain factual details about my medical history in relation to this application. ",
+    "paragraph2" : "I understand that:",
+    "listElement1": "my doctor may share personal data with the Home Office concerning my physical and mental health, to enable them to make a decision about my application, and I consent to this processing of my personal data.",
+    "listElement2": "the Home Office will tell my doctor the result of my application for an EPP licence and may also consult my doctor during the term of the licence."
+  },
+
   "confirm": {
     "header": "Check your answers",
     "subheader": "Check your answers before paying and submitting your renewal application.",
@@ -24,6 +32,9 @@
       },
       "new-renew-contact-details": {
         "header": "Contact details"
+      },
+      "medical-information":{
+        "header": "Medical information"
       }
     },
     "title": "Check your answers – Apply for an explosives precursors and poisons licence",
@@ -37,6 +48,9 @@
       },
       "new-renew-email": {
         "label": "Email address"
+      },
+      "medical-declaration": {
+        "label": "Medical declaration"
       }
     }
   },

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -26,5 +26,8 @@
     "new-renew-email": {
         "required": "Enter a contact email address",
         "email": "Enter a real email address"
+    },
+    "medical-declaration": {
+        "required" : "Confirm you have read and agree to this medical declaration"
     }
 }

--- a/apps/epp-new/views/medical-declaration.html
+++ b/apps/epp-new/views/medical-declaration.html
@@ -1,0 +1,16 @@
+{{<partials-page}}
+ {{$page-content}}
+  <div>
+    <p class="govuk-body">{{#t}}pages.medical-declaration.paragraph1{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.medical-declaration.paragraph2{{/t}}</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{#t}}pages.medical-declaration.listElement1{{/t}}</li>
+        <li>{{#t}}pages.medical-declaration.listElement2{{/t}}</li>
+    </ul>
+  </div>
+  {{#fields}}
+    {{#renderField}}{{/renderField}}
+  {{/fields}}
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}


### PR DESCRIPTION
## What? 
Create a MEDICAL DECLARATION page for new and renew page
## Why? 
as per jira business request ticket specifications [EPP-74](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-74)
## How? 
-add fields in :
- fieds/index.js,
- page.json,
- field.json,
- new/index.js
- add sections in summary-data-sections.js
- add validation.json
- add some content in pages.json
- create a custom html page
## Testing?
manual
## Screenshots (optional)
## Anything Else? (optional)
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
