### PR TITLE
EPP-75-newRenew-medical-history

### DIFF
--- a/apps/epp-new/behaviours/section-counter.js
+++ b/apps/epp-new/behaviours/section-counter.js
@@ -6,12 +6,9 @@ module.exports = superclass =>
       const locals = super.locals(req, res);
       if (locals?.sectionNo) {
         const isRenewJourney = req.sessionModel.get('isRenewJourney');
-        // Increment the sectionNo globally
-        const sectionNo = {
-          new: locals.sectionNo.new + 1,
-          renew: locals.sectionNo.renew + 1
-        };
-        const currentSection = isRenewJourney ? sectionNo.renew : sectionNo.new;
+        const currentSection = isRenewJourney
+          ? locals.sectionNo.renew
+          : locals.sectionNo.new;
         const totalSections = isRenewJourney ? totalStepsRenew : totalStepsNew;
         const captionHeading = `Section ${currentSection} of ${totalSections}`;
         locals.captionHeading = captionHeading;

--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -54,5 +54,30 @@ module.exports = {
     validate: ['required', 'email'],
     className: ['govuk-input'],
     labelClassName: 'govuk-label--m'
+  },
+
+  'new-renew-has-seen-doctor': {
+    mixin: 'radio-group',
+    options: [
+      {value: 'yes'},
+      {value: 'no'}
+    ],
+    validate: ['required'],
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'govuk-fieldset__legend'
+    }
+  },
+  'new-renew-received-treatment': {
+    mixin: 'radio-group',
+    options: [
+      {value: 'yes'},
+      {value: 'no'}
+    ],
+    validate: ['required'],
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'govuk-fieldset__legend'
+    }
   }
 };

--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -59,28 +59,22 @@ module.exports = {
     mixin: 'checkbox',
     validate: ['required']
   },
-    'new-renew-has-seen-doctor': {
-      mixin: 'radio-group',
-      options: [
-        {value: 'yes'},
-        {value: 'no'}
-      ],
-      validate: ['required'],
-      className: ['govuk-radios', 'govuk-radios--inline'],
-      legend: {
-        className: 'govuk-fieldset__legend'
-      }
-    },
-    'new-renew-received-treatment': {
-      mixin: 'radio-group',
-      options: [
-        {value: 'yes'},
-        {value: 'no'}
-      ],
-      validate: ['required'],
-      className: ['govuk-radios', 'govuk-radios--inline'],
-      legend: {
-        className: 'govuk-fieldset__legend'
-      }
+  'new-renew-has-seen-doctor': {
+    mixin: 'radio-group',
+    options: [{ value: 'yes' }, { value: 'no' }],
+    validate: ['required'],
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'govuk-fieldset__legend'
     }
+  },
+  'new-renew-received-treatment': {
+    mixin: 'radio-group',
+    options: [{ value: 'yes' }, { value: 'no' }],
+    validate: ['required'],
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    legend: {
+      className: 'govuk-fieldset__legend'
+    }
+  }
 };

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -255,8 +255,15 @@ module.exports = {
       }
     },
     '/medical-history': {
-      fields: [],
-      // add fork for medical-form
+      fields: ['new-renew-has-seen-doctor', 'new-renew-received-treatment'],
+      forks: [{
+        target: '/medical-form',
+        continueOnEdit: true,
+        condition: {
+          field: 'new-renew-received-treatment',
+          value: 'yes'
+        }
+      }],
       next: '/doctor-details',
       locals: {
         sectionNo: {

--- a/apps/epp-new/sections/summary-data-sections.js
+++ b/apps/epp-new/sections/summary-data-sections.js
@@ -42,5 +42,18 @@ module.exports = {
         field: 'new-renew-email'
       }
     ]
+  },
+
+  'medical-information': {
+    steps: [
+      {
+        step: '/medical-history',
+        field: 'new-renew-has-seen-doctor'
+      },
+      {
+        step: '/medical-history',
+        field: 'new-renew-received-treatment'
+      }
+    ]
   }
 };

--- a/apps/epp-new/sections/summary-data-sections.js
+++ b/apps/epp-new/sections/summary-data-sections.js
@@ -51,19 +51,15 @@ module.exports = {
         // TODO: can this be configured in translation?
         parse: value =>
           value ? 'I have read and agree to the medical declarations' : ''
+      },
+      {
+        step: '/medical-history',
+        field: 'new-renew-has-seen-doctor'
+      },
+      {
+        step: '/medical-history',
+        field: 'new-renew-received-treatment'
       }
     ]
-  },
-    'medical-information': {
-      steps: [
-        {
-          step: '/medical-history',
-          field: 'new-renew-has-seen-doctor'
-        },
-        {
-          step: '/medical-history',
-          field: 'new-renew-received-treatment'
-        }
-      ]
-    }
+  }
 };

--- a/apps/epp-new/translations/src/en/fields.json
+++ b/apps/epp-new/translations/src/en/fields.json
@@ -36,5 +36,29 @@
   "new-renew-email": {
     "label": "Email address",
     "hint": "Where we will contact you about the outcome of your application"
+  },
+
+  "new-renew-has-seen-doctor":{
+    "legend": "In the last 10 years, have you seen a doctor or received professional medical advice or treatment for any mental health-related problems?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  }, 
+  "new-renew-received-treatment" : {
+    "legend": "Have you ever had, or received treatment for, any drug or alcohol-related health problems?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+
   }
 }

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -15,6 +15,16 @@
     "title": "What are your contact details?",
     "header": "What are your contact details?"
   },
+  "medical-history": {
+    "header": "Your medical history",
+    "paragraph1": "You must tell us about any mental health problems you have received medical advice or treatment for.",
+    "paragraph2": "Mental health problems include:",
+    "listElement1": "suicidal thoughts or self-harm",
+    "listElement2": "depression",
+    "listElement3": "mania, bipolar disorder or psychotic illness",
+    "listElement4": "personality disorders",
+    "listElement5": "any other mental health conditions you consider relevant"
+  },
   "confirm": {
     "header": "Check your answers",
     "subheader": "Check your answers before paying and submitting your renewal application.",
@@ -24,6 +34,9 @@
       },
       "new-renew-contact-details": {
         "header": "Contact details"
+      },
+      "medical-information": {
+        "header": " Medical information"
       }
     },
     "title": "Check your answers – Apply for an explosives precursors and poisons licence",
@@ -37,6 +50,12 @@
       },
       "new-renew-email": {
         "label": "Email address"
+      },
+      "new-renew-has-seen-doctor":{
+        "label": "Seen a doctor for metal health-related problems?" 
+      },
+      "new-renew-received-treatment" : {
+        "label": "Have you ever had, or received treatment for, any drug or alcohol-related health problems?"
       }
     }
   },

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -26,5 +26,11 @@
     "new-renew-email": {
         "required": "Enter a contact email address",
         "email": "Enter a real email address"
-    }
+    },
+    "new-renew-has-seen-doctor":{
+        "required": "Select if you have seen a doctor for any mental health-related problems" 
+      },
+      "new-renew-received-treatment" : {
+        "required": "Select if you have ever had any drug or alcohol-related health problems?"
+      }
 }

--- a/apps/epp-new/views/medical-history.html
+++ b/apps/epp-new/views/medical-history.html
@@ -1,0 +1,19 @@
+{{<partials-page}}
+ {{$page-content}}
+  <div>
+    <p class="govuk-body">{{#t}}pages.medical-history.paragraph1{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.medical-history.paragraph2{{/t}}</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{#t}}pages.medical-history.listElement1{{/t}}</li>
+        <li>{{#t}}pages.medical-history.listElement2{{/t}}</li>
+        <li>{{#t}}pages.medical-history.listElement3{{/t}}</li>
+        <li>{{#t}}pages.medical-history.listElement4{{/t}}</li>
+        <li>{{#t}}pages.medical-history.listElement5{{/t}}</li>
+    </ul>
+  </div>
+  {{#fields}}
+    {{#renderField}}{{/renderField}}
+  {{/fields}}
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}


### PR DESCRIPTION
## What? 
Create a YOUR MEDICAL HISTORY page
## Why? 
as per business request specified in jira ticket [EPP-75](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-75)
## How? 
add new fields :
* `new-renew-has-seen-doctor`
* `new-renew-received-treatment`

in the following files:
- index.js
- fields/index.js
- page.json
- validation.json
- fields.json
- create `medical-history.html`
- add steps in `summary data stections`

- add logic if `new-renew-received-treatment` value is "yes" redirect to `/new-renew/medical-form`
- add "continueOnEdit" property to keep the redirection to medical form page incase response change from "no" to "yes" when edit from confirm page

## Testing?
manual
## Screenshots (optional)
## Anything Else? (optional)
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
