### PR TITLE
EPP-115 Configure Notify template ids

### DIFF
--- a/config.js
+++ b/config.js
@@ -12,10 +12,18 @@ module.exports = {
     year: 'numeric'
   },
   env: env,
-  email: {
+  govukNotify: {
     notifyApiKey: process.env.NOTIFY_KEY,
-    notifyTemplate: process.env.NOTIFY_TEMPLATE,
-    caseWorker: process.env.CASEWORKER_EMAIL
+    caseworkerEmail: process.env.CASEWORKER_EMAIL,
+    newApplicationUserTemplateId: process.env.NEW_APPLICATION_USER_TEMPLATE_ID,
+    newApplicationBusinessTemplateId: process.env.NEW_APPLICATION_BUSINESS_TEMPLATE_ID,
+    renewApplicationUserTemplateId: process.env.RENEW_APPLICATION_USER_TEMPLATE_ID,
+    renewApplicationBusinessTemplateId: process.env.RENEW_APPLICATION_BUSINESS_TEMPLATE_ID,
+    amendApplicationUserTemplateId: process.env.AMEND_APPLICATION_USER_TEMPLATE_ID,
+    amendApplicationBusinessTemplateId: process.env.AMEND_APPLICATION_BUSINESS_TEMPLATE_ID,
+    replaceApplicationUserTemplateId: process.env.REPLACE_APPLICATION_USER_TEMPLATE_ID,
+    replaceDamagedApplicationUserTemplateId: process.env.REPLACE_DAMAGED_APPLICATION_USER_TEMPLATE_ID,
+    replaceApplicationBusinessTemplateId: process.env.REPLACE_APPLICATION_BUSINESS_TEMPLATE_ID
   },
   // TODO: set return URL and mac in env variables
   feedback: {


### PR DESCRIPTION
## What? 
[EPP-115](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-115) - Setup notify templates
## Why? 
Notify templates are created for prod and not prod. 
## How? 

- Prod and not prod template created
- hof-service-config updated with the template ids - https://github.com/UKHomeOfficeForms/hof-services-config/pull/447
- template ids are updated in service-secrets 

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
