### PR TITLE
EPP-159: Add HTML-PDF-CONVERTER deployment to EPP

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -161,6 +161,7 @@ steps:
         memory: 1024Mi
     environment:
       IMAGE_NAME: sas/epp:${DRONE_COMMIT_SHA}
+      SERVICE_URL: https://acp-trivy-helm.acp-trivy.svc.cluster.local:443      
       SEVERITY: MEDIUM,HIGH,CRITICAL  --dependency-tree --format table
       FAIL_ON_DETECTION: false
       IGNORE_UNFIXED: false
@@ -365,7 +366,7 @@ steps:
     pull: always
     environment:
         IMAGE_NAME: sas/epp:${DRONE_COMMIT_SHA}
-        SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
+        SERVICE_URL: https://acp-trivy-helm.acp-trivy.svc.cluster.local:443
         SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --dependency-tree
         FAIL_ON_DETECTION: true
         IGNORE_UNFIXED: false
@@ -384,6 +385,7 @@ steps:
     pull: always
     environment:
         IMAGE_NAME: node:20.18.0-alpine3.20@sha256:d504f23acdda979406cf3bdbff0dff7933e5c4ec183dda404ed24286c6125e60
+        SERVICE_URL: https://acp-trivy-helm.acp-trivy.svc.cluster.local:443
         SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --dependency-tree
         FAIL_ON_DETECTION: false
         IGNORE_UNFIXED: false

--- a/.drone.yml
+++ b/.drone.yml
@@ -370,8 +370,6 @@ steps:
     when:
       cron: security_scans
       event: cron
-    depends_on:
-      - cron_build_image   
 
   - name: cron_trivy_scan_image_os
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest

--- a/.drone.yml
+++ b/.drone.yml
@@ -151,7 +151,7 @@ steps:
         <<: *include_default_and_feature_branches
       event: [push, pull_request]
     depends_on:
-      - linting
+      - build_image
 
   # Trivy Security Scannner for scanning nodejs packages in Yarn
   - name: scan_node_packages
@@ -173,7 +173,7 @@ steps:
     when:
       event: [push, pull_request]
     depends_on:
-      - build_image
+      - image_to_ecr
 
   - name: deploy_to_branch
     pull: if-not-exists
@@ -265,8 +265,7 @@ steps:
       branch: master
       event: push
     depends_on:
-      - clone_repos
-      - image_to_ecr
+      - deploy_to_uat
 
   ## Checks a build being promoted has passed, is on master which effectively means a healthy build on Staging
   - name: sanity_check_build_prod

--- a/.drone.yml
+++ b/.drone.yml
@@ -111,10 +111,8 @@ steps:
   # - name: sonar_scanner
   #   <<: *sonar_scanner
   #   when:
-  #     branch:
-  #       include:
-  #         - master
-  #         - feature/*
+  #    branch:
+  #      <<: *include_default_and_feature_branches
   #     event: [push, pull_request]
 
   - name: build_image
@@ -151,7 +149,7 @@ steps:
         <<: *include_default_and_feature_branches
       event: [push, pull_request]
     depends_on:
-      - build_image
+      - linting
 
   # Trivy Security Scannner for scanning nodejs packages in Yarn
   - name: scan_node_packages
@@ -173,7 +171,7 @@ steps:
     when:
       event: [push, pull_request]
     depends_on:
-      - image_to_ecr
+      - build_image
 
   - name: deploy_to_branch
     pull: if-not-exists
@@ -205,8 +203,8 @@ steps:
       - sh bin/deploy.sh $${UAT_ENV}
     when:
       branch:
-        include:
-          - master
+      branch:
+        <<: *include_default_branch
       event: push
     depends_on:
       - clone_repos
@@ -227,7 +225,8 @@ steps:
     commands:
       - drone build info $GIT_REPO $DRONE_BUILD_NUMBER --format {{.Message}} | grep -o '[^ ]\+$' -m1 | sed 's|UKHomeOffice/||g' | tr '[:upper:]' '[:lower:]' | tr '/' '-' > /root/.dockersock/branch_name.txt
     when:
-      branch: master
+      branch:
+        <<: *include_default_branch
       event: push
 
   # Tear down pull request UAT environment
@@ -245,10 +244,12 @@ steps:
     commands:
       - bin/deploy.sh tear_down
     when:
-      branch: master
+      branch:
+        <<: *include_default_branch
       event: push
     depends_on:
       - get_pr_branch
+      - deploy_to_uat
 
   # Deploy to Staging environment
   - name: deploy_to_stg
@@ -262,10 +263,12 @@ steps:
     commands:
       - bin/deploy.sh $${STG_ENV}
     when:
-      branch: master
+      branch:
+        <<: *include_default_branch
       event: push
     depends_on:
-      - deploy_to_uat
+      - clone_repos
+      - image_to_ecr
 
   ## Checks a build being promoted has passed, is on master which effectively means a healthy build on Staging
   - name: sanity_check_build_prod
@@ -364,12 +367,17 @@ steps:
         IMAGE_NAME: sas/epp:${DRONE_COMMIT_SHA}
         SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
         SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --dependency-tree
-        FAIL_ON_DETECTION: false
+        FAIL_ON_DETECTION: true
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
     when:
       cron: security_scans
       event: cron
+      status:
+        - success
+        - failure
+    depends_on:
+      - cron_build_image
 
   - name: cron_trivy_scan_image_os
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
@@ -383,6 +391,8 @@ steps:
     when:
       cron: security_scans
       event: cron
+    depends_on:
+      - cron_clone_repos
 
   # Slack notification upon a CRON job fail
   - name: cron_notify_slack_tear_down_pr_envs
@@ -404,7 +414,10 @@ steps:
     when:
       cron: tear_down_pr_envs
       event: cron
-      status: failure
+      status:
+        - failure
+    depends_on:
+      - cron_tear_down
   
   - name: cron_notify_slack_security_scans
     pull: if-not-exists
@@ -425,7 +438,11 @@ steps:
     when:
       cron: security_scans
       event: cron
-      status: failure
+      status:
+        - failure
+    depends_on:
+      - cron_trivy_scan_image_os
+      - cron_trivy_scan_node_packages
 
 services:
   - name: docker

--- a/kube/html-pdf/html-pdf-deployment.yml
+++ b/kube/html-pdf/html-pdf-deployment.yml
@@ -1,0 +1,86 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
+  name: html-pdf-converter
+  {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+  annotations:
+    downscaler/uptime: {{ .NON_PROD_AVAILABILITY }}
+  name: html-pdf-converter-{{ .DRONE_SOURCE_BRANCH }}
+  {{ else }}
+  annotations:
+    downscaler/uptime: {{ .NON_PROD_AVAILABILITY }}
+  name: html-pdf-converter
+  {{ end }}
+spec:
+  selector:
+    matchLabels:
+      {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+      name: html-pdf-converter-{{ .DRONE_SOURCE_BRANCH }}
+      {{ else }}
+      name: html-pdf-converter
+      {{ end }}
+  template:
+    metadata:
+      labels:
+        {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+        name: html-pdf-converter-{{ .DRONE_SOURCE_BRANCH }}
+        service: html-pdf-converter-{{ .DRONE_SOURCE_BRANCH }}
+        {{ else }}
+        name: html-pdf-converter
+        service: html-pdf-converter
+        {{ end }}
+    spec:
+      containers:
+        {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+        - name: html-pdf-converter-{{ .DRONE_SOURCE_BRANCH }}
+        {{ else }}
+        - name: html-pdf-converter
+        {{ end }}
+          # html-pdf-converter:v2.1.0
+          image: quay.io/ukhomeofficedigital/html-pdf-converter@sha256:45814848f0c1d56169ab90990891b03d52d59d7558255cfca8ed2ce2a02d034e
+          imagePullPolicy: Always
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 10m
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          env:
+            - name: APP_PORT
+              value: "8001"
+          securityContext:
+            runAsNonRoot: true
+
+        - name: nginx-proxy
+          # nginx-proxy-govuk:v4
+          image: quay.io/ukhomeofficedigital/nginx-proxy-govuk@sha256:4470064d0b1d20ae08c5fd85551576cb687f342a22d6cb456fda9b2c4ce8c8df
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 10m
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          env:
+            - name: PROXY_SERVICE_HOST
+              value: 127.0.0.1
+            - name: PROXY_SERVICE_PORT
+              value: "8001"
+            - name: ENABLE_UUID_PARAM
+              value: "FALSE"
+            - name: HTTPS_REDIRECT
+              value: "FALSE"
+            - name: NAXSI_USE_DEFAULT_RULES
+              value: "FALSE"
+            - name: PORT_IN_HOST_HEADER
+              value: "FALSE"
+            - name: ERROR_REDIRECT_CODES
+              value: "599"
+          securityContext:
+            runAsNonRoot: true
+          ports:
+            - containerPort: 10080
+            - containerPort: 10443

--- a/kube/html-pdf/html-pdf-network-policy.yml
+++ b/kube/html-pdf/html-pdf-network-policy.yml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+  name: html-pdf-converter-allow-ingress-{{ .DRONE_SOURCE_BRANCH }}
+  {{ else }}
+  name: html-pdf-converter-allow-ingress
+  {{ end }}
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: {{ .KUBE_NAMESPACE }}
+    ports:
+    - port: 10080
+      protocol: TCP
+    - port: 10443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+      name: html-pdf-converter-{{ .DRONE_SOURCE_BRANCH }}
+      {{ else }}
+      name: html-pdf-converter
+      {{ end }}
+  policyTypes:
+  - Ingress

--- a/kube/html-pdf/html-pdf-service.yml
+++ b/kube/html-pdf/html-pdf-service.yml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+  name: html-pdf-converter-{{ .DRONE_SOURCE_BRANCH }}
+  labels:
+    name: html-pdf-converter-{{ .DRONE_SOURCE_BRANCH }}
+    role: service
+  {{ else }}
+  name: html-pdf-converter
+  labels:
+    name: html-pdf-converter
+    role: service
+  {{ end }}
+spec:
+  ports:
+  - name: http
+    port: 10080
+  - name: https
+    port: 10443
+  selector:
+    {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+    name: html-pdf-converter-{{ .DRONE_SOURCE_BRANCH }}
+    {{ else }}
+    name: html-pdf-converter
+    {{ end }}


### PR DESCRIPTION
## What? 
* The current email to users contains the form data in the email but also a pdf attachment.
* system design is similar to the Firearms service
* EPP is using the Image tags of recent services like FMR
* https://collaboration.homeoffice.gov.uk/jira/browse/EPP-159
* Rearrange order of Drone Steps execution

## Why? 
* HTML is rendered and sent as PDF attachment using this microservice

## How? 
* Service, Ingress and depoyments are created with the added files

## Testing?
* Once the form is completed and tested. Upon Submitting the form we expect to receive an email using gov notify key to hof test email box. Then we can validate and make any changes further

## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
