### PR TITLE
EPP-91, 92, 93 - countersignatory details, address, contact details pages

### DIFF
--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -340,5 +340,56 @@ module.exports = {
     validate: ['required', 'notUrl'],
     labelClassName: 'govuk-label--s',
     className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'new-renew-countersignatory-address-1': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds'],
+    validate: [
+      'required',
+      { type: 'minlength', arguments: 2 },
+      { type: 'maxlength', arguments: 250 },
+      'notUrl'
+    ]
+  },
+  'new-renew-countersignatory-address-2': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds'],
+    validate: [
+      { type: 'minlength', arguments: 2 },
+      { type: 'maxlength', arguments: 250 },
+      'notUrl'
+    ]
+  },
+  'new-renew-countersignatory-town-or-city': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds'],
+    validate: [
+      'required',
+      { type: 'minlength', arguments: 2 },
+      { type: 'maxlength', arguments: 250 },
+      'notUrl'
+    ]
+  },
+  'new-renew-countersignatory-postcode': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds'],
+    validate: ['required', 'postcode'],
+    formatter: ['ukPostcode']
+  },
+  'new-renew-countersignatory-phone-number': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl', 'internationalPhoneNumber'],
+    className: ['govuk-input', 'govuk-!-width-one-half'],
+    labelClassName: 'govuk-label--m'
+  },
+  'new-renew-countersignatory-email': {
+    mixin: 'input-text',
+    validate: ['required', 'email'],
+    className: ['govuk-input'],
+    labelClassName: 'govuk-label--m'
   }
 };

--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -2,6 +2,7 @@ const dateComponent = require('hof').components.date;
 const titles = require('../../../utilities/constants/titles');
 const countries = require('../../../utilities/constants/countries');
 const { isWithoutFullStop } = require('../../../utilities/helpers');
+const countersignatoryYears = require('../../../utilities/constants/countersignatory-years');
 
 module.exports = {
   'new-renew-title': {
@@ -285,5 +286,59 @@ module.exports = {
     legend: {
       className: ['govuk-fieldset__legend, bold']
     }
+  },
+  'new-renew-countersignatory-title': {
+    mixin: 'select',
+    validate: 'required',
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-select', 'govuk-input--width-2'],
+    options: [
+      {
+        value: '',
+        label: 'fields.new-renew-countersignatory-title.options.none_selected'
+      }
+    ].concat(titles)
+  },
+  'new-renew-countersignatory-firstname': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl'],
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'new-renew-countersignatory-middlename': {
+    mixin: 'input-text',
+    validate: ['notUrl', { type: 'maxlength', arguments: [250] }],
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'new-renew-countersignatory-lastname': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }],
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'new-renew-countersignatory-years': {
+    mixin: 'select',
+    validate: 'required',
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-select', 'govuk-input--width-2'],
+    options: [
+      {
+        value: '',
+        label: 'fields.new-renew-countersignatory-years.options.none_selected'
+      }
+    ].concat(countersignatoryYears)
+  },
+  'new-renew-countersignatory-howyouknow': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl'],
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'new-renew-countersignatory-occupation': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl'],
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
   }
 };

--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -1,7 +1,7 @@
 const dateComponent = require('hof').components.date;
 const titles = require('../../../utilities/constants/titles');
 const countries = require('../../../utilities/constants/countries');
-const { isWithoutFullStop } = require('../../../utilities/helpers');
+const { isWithoutFullStop, validInternationalPhoneNumber } = require('../../../utilities/helpers');
 const countersignatoryYears = require('../../../utilities/constants/countersignatory-years');
 
 module.exports = {
@@ -382,7 +382,7 @@ module.exports = {
   },
   'new-renew-countersignatory-phone-number': {
     mixin: 'input-text',
-    validate: ['required', 'notUrl', 'internationalPhoneNumber'],
+    validate: ['required', 'notUrl', validInternationalPhoneNumber],
     className: ['govuk-input', 'govuk-!-width-one-half'],
     labelClassName: 'govuk-label--m'
   },

--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -372,7 +372,7 @@ module.exports = {
   },
   'new-renew-countersignatory-firstname': {
     mixin: 'input-text',
-    validate: ['required', 'notUrl'],
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }],
     labelClassName: 'govuk-label--s'
   },
   'new-renew-countersignatory-middlename': {

--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -1,7 +1,10 @@
 const dateComponent = require('hof').components.date;
 const titles = require('../../../utilities/constants/titles');
 const countries = require('../../../utilities/constants/countries');
-const { isWithoutFullStop, validInternationalPhoneNumber } = require('../../../utilities/helpers');
+const {
+  isWithoutFullStop,
+  validInternationalPhoneNumber
+} = require('../../../utilities/helpers');
 const countersignatoryYears = require('../../../utilities/constants/countersignatory-years');
 
 module.exports = {
@@ -355,109 +358,109 @@ module.exports = {
       validate: ['required', 'date', 'before']
     }
   ),
-    'new-renew-countersignatory-title': {
-        mixin: 'select',
-        validate: 'required',
-        labelClassName: 'govuk-label--s',
-        className: ['govuk-select', 'govuk-input--width-2'],
-        options: [
-            {
-                value: '',
-                label: 'fields.new-renew-countersignatory-title.options.none_selected'
-            }
-        ].concat(titles)
-    },
-    'new-renew-countersignatory-firstname': {
-        mixin: 'input-text',
-        validate: ['required', 'notUrl'],
-        labelClassName: 'govuk-label--s',
-        className: ['govuk-input', 'govuk-!-width-two-thirds']
-    },
-    'new-renew-countersignatory-middlename': {
-        mixin: 'input-text',
-        validate: ['notUrl', { type: 'maxlength', arguments: [250] }],
-        labelClassName: 'govuk-label--s',
-        className: ['govuk-input', 'govuk-!-width-two-thirds']
-    },
-    'new-renew-countersignatory-lastname': {
-        mixin: 'input-text',
-        validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }],
-        labelClassName: 'govuk-label--s',
-        className: ['govuk-input', 'govuk-!-width-two-thirds']
-    },
-    'new-renew-countersignatory-years': {
-        mixin: 'select',
-        validate: 'required',
-        labelClassName: 'govuk-label--s',
-        className: ['govuk-select', 'govuk-input--width-2'],
-        options: [
-            {
-                value: '',
-                label: 'fields.new-renew-countersignatory-years.options.none_selected'
-            }
-        ].concat(countersignatoryYears)
-    },
-    'new-renew-countersignatory-howyouknow': {
-        mixin: 'input-text',
-        validate: ['required', 'notUrl'],
-        labelClassName: 'govuk-label--s',
-        className: ['govuk-input', 'govuk-!-width-two-thirds']
-    },
-    'new-renew-countersignatory-occupation': {
-        mixin: 'input-text',
-        validate: ['required', 'notUrl'],
-        labelClassName: 'govuk-label--s',
-        className: ['govuk-input', 'govuk-!-width-two-thirds']
-    },
-    'new-renew-countersignatory-address-1': {
-        mixin: 'input-text',
-        labelClassName: 'govuk-label--s',
-        className: ['govuk-input', 'govuk-!-width-two-thirds'],
-        validate: [
-            'required',
-            { type: 'minlength', arguments: 2 },
-            { type: 'maxlength', arguments: 250 },
-            'notUrl'
-        ]
-    },
-    'new-renew-countersignatory-address-2': {
-        mixin: 'input-text',
-        labelClassName: 'govuk-label--s',
-        className: ['govuk-input', 'govuk-!-width-two-thirds'],
-        validate: [
-            { type: 'minlength', arguments: 2 },
-            { type: 'maxlength', arguments: 250 },
-            'notUrl'
-        ]
-    },
-    'new-renew-countersignatory-town-or-city': {
-        mixin: 'input-text',
-        labelClassName: 'govuk-label--s',
-        className: ['govuk-input', 'govuk-!-width-two-thirds'],
-        validate: [
-            'required',
-            { type: 'minlength', arguments: 2 },
-            { type: 'maxlength', arguments: 250 },
-            'notUrl'
-        ]
-    },
-    'new-renew-countersignatory-postcode': {
-        mixin: 'input-text',
-        labelClassName: 'govuk-label--s',
-        className: ['govuk-input', 'govuk-!-width-two-thirds'],
-        validate: ['required', 'postcode'],
-        formatter: ['ukPostcode']
-    },
-    'new-renew-countersignatory-phone-number': {
-        mixin: 'input-text',
-        validate: ['required', 'notUrl', validInternationalPhoneNumber],
-        className: ['govuk-input', 'govuk-!-width-one-half'],
-        labelClassName: 'govuk-label--m'
-    },
-    'new-renew-countersignatory-email': {
-        mixin: 'input-text',
-        validate: ['required', 'email'],
-        className: ['govuk-input'],
-        labelClassName: 'govuk-label--m'
-    }
+  'new-renew-countersignatory-title': {
+    mixin: 'select',
+    validate: 'required',
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-select', 'govuk-input--width-2'],
+    options: [
+      {
+        value: '',
+        label: 'fields.new-renew-countersignatory-title.options.none_selected'
+      }
+    ].concat(titles)
+  },
+  'new-renew-countersignatory-firstname': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl'],
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'new-renew-countersignatory-middlename': {
+    mixin: 'input-text',
+    validate: ['notUrl', { type: 'maxlength', arguments: [250] }],
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'new-renew-countersignatory-lastname': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }],
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'new-renew-countersignatory-years': {
+    mixin: 'select',
+    validate: 'required',
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-select', 'govuk-input--width-2'],
+    options: [
+      {
+        value: '',
+        label: 'fields.new-renew-countersignatory-years.options.none_selected'
+      }
+    ].concat(countersignatoryYears)
+  },
+  'new-renew-countersignatory-howyouknow': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl'],
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'new-renew-countersignatory-occupation': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl'],
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'new-renew-countersignatory-address-1': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds'],
+    validate: [
+      'required',
+      { type: 'minlength', arguments: 2 },
+      { type: 'maxlength', arguments: 250 },
+      'notUrl'
+    ]
+  },
+  'new-renew-countersignatory-address-2': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds'],
+    validate: [
+      { type: 'minlength', arguments: 2 },
+      { type: 'maxlength', arguments: 250 },
+      'notUrl'
+    ]
+  },
+  'new-renew-countersignatory-town-or-city': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds'],
+    validate: [
+      'required',
+      { type: 'minlength', arguments: 2 },
+      { type: 'maxlength', arguments: 250 },
+      'notUrl'
+    ]
+  },
+  'new-renew-countersignatory-postcode': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds'],
+    validate: ['required', 'postcode'],
+    formatter: ['ukPostcode']
+  },
+  'new-renew-countersignatory-phone-number': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl', validInternationalPhoneNumber],
+    className: ['govuk-input', 'govuk-!-width-one-half'],
+    labelClassName: 'govuk-label--m'
+  },
+  'new-renew-countersignatory-email': {
+    mixin: 'input-text',
+    validate: ['required', 'email'],
+    className: ['govuk-input'],
+    labelClassName: 'govuk-label--m'
+  }
 };

--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -373,20 +373,17 @@ module.exports = {
   'new-renew-countersignatory-firstname': {
     mixin: 'input-text',
     validate: ['required', 'notUrl'],
-    labelClassName: 'govuk-label--s',
-    className: ['govuk-input', 'govuk-!-width-two-thirds']
+    labelClassName: 'govuk-label--s'
   },
   'new-renew-countersignatory-middlename': {
     mixin: 'input-text',
     validate: ['notUrl', { type: 'maxlength', arguments: [250] }],
-    labelClassName: 'govuk-label--s',
-    className: ['govuk-input', 'govuk-!-width-two-thirds']
+    labelClassName: 'govuk-label--s'
   },
   'new-renew-countersignatory-lastname': {
     mixin: 'input-text',
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }],
-    labelClassName: 'govuk-label--s',
-    className: ['govuk-input', 'govuk-!-width-two-thirds']
+    labelClassName: 'govuk-label--s'
   },
   'new-renew-countersignatory-years': {
     mixin: 'select',
@@ -402,20 +399,17 @@ module.exports = {
   },
   'new-renew-countersignatory-howyouknow': {
     mixin: 'input-text',
-    validate: ['required', 'notUrl'],
-    labelClassName: 'govuk-label--s',
-    className: ['govuk-input', 'govuk-!-width-two-thirds']
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }],
+    labelClassName: 'govuk-label--s'
   },
   'new-renew-countersignatory-occupation': {
     mixin: 'input-text',
-    validate: ['required', 'notUrl'],
-    labelClassName: 'govuk-label--s',
-    className: ['govuk-input', 'govuk-!-width-two-thirds']
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }],
+    labelClassName: 'govuk-label--s'
   },
   'new-renew-countersignatory-address-1': {
     mixin: 'input-text',
     labelClassName: 'govuk-label--s',
-    className: ['govuk-input', 'govuk-!-width-two-thirds'],
     validate: [
       'required',
       { type: 'minlength', arguments: 2 },
@@ -426,7 +420,6 @@ module.exports = {
   'new-renew-countersignatory-address-2': {
     mixin: 'input-text',
     labelClassName: 'govuk-label--s',
-    className: ['govuk-input', 'govuk-!-width-two-thirds'],
     validate: [
       { type: 'minlength', arguments: 2 },
       { type: 'maxlength', arguments: 250 },
@@ -436,7 +429,6 @@ module.exports = {
   'new-renew-countersignatory-town-or-city': {
     mixin: 'input-text',
     labelClassName: 'govuk-label--s',
-    className: ['govuk-input', 'govuk-!-width-two-thirds'],
     validate: [
       'required',
       { type: 'minlength', arguments: 2 },
@@ -447,7 +439,7 @@ module.exports = {
   'new-renew-countersignatory-postcode': {
     mixin: 'input-text',
     labelClassName: 'govuk-label--s',
-    className: ['govuk-input', 'govuk-!-width-two-thirds'],
+    className: ['govuk-input', 'govuk-input--width-10'],
     validate: ['required', 'postcode'],
     formatter: ['ukPostcode']
   },

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -437,7 +437,12 @@ module.exports = {
       }
     },
     '/countersignatory-address': {
-      fields: [],
+      fields: [
+        'new-renew-countersignatory-address-1',
+        'new-renew-countersignatory-address-2',
+        'new-renew-countersignatory-town-or-city',
+        'new-renew-countersignatory-postcode'
+      ],
       next: '/countersignatory-contact',
       locals: {
         sectionNo: {
@@ -447,7 +452,10 @@ module.exports = {
       }
     },
     '/countersignatory-contact': {
-      fields: [],
+      fields: [
+        'new-renew-countersignatory-phone-number',
+        'new-renew-countersignatory-email'
+      ],
       next: '/countersignatory-id',
       locals: {
         sectionNo: {

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -419,7 +419,15 @@ module.exports = {
       }
     },
     '/countersignatory-details': {
-      fields: [],
+      fields: [
+        'new-renew-countersignatory-title',
+        'new-renew-countersignatory-firstname',
+        'new-renew-countersignatory-middlename',
+        'new-renew-countersignatory-lastname',
+        'new-renew-countersignatory-years',
+        'new-renew-countersignatory-howyouknow',
+        'new-renew-countersignatory-occupation'
+      ],
       next: '/countersignatory-address',
       locals: {
         sectionNo: {

--- a/apps/epp-new/sections/summary-data-sections.js
+++ b/apps/epp-new/sections/summary-data-sections.js
@@ -189,5 +189,63 @@ module.exports = {
         field: 'new-renew-received-treatment'
       }
     ]
+  },
+  'countersignatory-details': {
+    steps: [
+      {
+        step: '/countersignatory-details',
+        field: 'new-renew-countersignatory-title'
+      },
+      {
+        step: '/countersignatory-details',
+        field: 'new-renew-countersignatory-firstname'
+      },
+      {
+        step: '/countersignatory-details',
+        field: 'new-renew-countersignatory-middlename',
+        parse: value => value || 'Not provided'
+      },
+      {
+        step: '/countersignatory-details',
+        field: 'new-renew-countersignatory-lastname'
+      },
+      {
+        step: '/countersignatory-details',
+        field: 'new-renew-countersignatory-years'
+      },
+      {
+        step: '/countersignatory-details',
+        field: 'new-renew-countersignatory-howyouknow'
+      },
+      {
+        step: '/countersignatory-details',
+        field: 'new-renew-countersignatory-occupation'
+      },
+      {
+        step: '/countersignatory-address',
+        field: 'new-renew-countersignatory-address-1'
+      },
+      {
+        step: '/countersignatory-address',
+        field: 'new-renew-countersignatory-address-2',
+        parse: value => value || 'Not provided'
+      },
+      {
+        step: '/countersignatory-address',
+        field: 'new-renew-countersignatory-town-or-city'
+      },
+      {
+        step: '/countersignatory-address',
+        field: 'new-renew-countersignatory-postcode'
+      },
+      {
+        step: '/countersignatory-contact',
+        field: 'new-renew-countersignatory-phone-number'
+      },
+      {
+        step: '/countersignatory-contact',
+        field: 'new-renew-countersignatory-email'
+      }
+    ]
   }
 };

--- a/apps/epp-new/translations/src/en/fields.json
+++ b/apps/epp-new/translations/src/en/fields.json
@@ -196,5 +196,33 @@
         "label": "No"
       }
     }
+  },
+  "new-renew-countersignatory-title":{
+    "label": "Title",
+    "options": {
+      "none_selected": "Select"
+    }
+  },
+  "new-renew-countersignatory-firstname":{
+    "label": "First name"
+  },
+  "new-renew-countersignatory-middlename":{
+    "label": "Middle names (optional)"
+  },
+  "new-renew-countersignatory-lastname":{
+    "label": "Last name"
+  },
+  "new-renew-countersignatory-years": {
+    "label": "How many years have you known your countersignatory?",
+    "hint": "They must have known you for at least 2 years",
+    "options": {
+      "none_selected": "Select"
+    }
+  },
+  "new-renew-countersignatory-howyouknow":{
+    "label": "How do you know your countersignatory?"
+  },
+  "new-renew-countersignatory-occupation":{
+    "label": "What is your countersignatory’s occupation?"
   }
 }

--- a/apps/epp-new/translations/src/en/fields.json
+++ b/apps/epp-new/translations/src/en/fields.json
@@ -224,5 +224,24 @@
   },
   "new-renew-countersignatory-occupation":{
     "label": "What is your countersignatory’s occupation?"
+  },
+  "new-renew-countersignatory-address-1": {
+    "label": "Address line 1"
+  },
+  "new-renew-countersignatory-address-2": {
+    "label": "Address line 2 (optional)"
+  },
+  "new-renew-countersignatory-town-or-city": {
+    "label": "Town or city"
+  },
+  "new-renew-countersignatory-postcode": {
+    "label": "Postcode"
+  },
+  "new-renew-countersignatory-phone-number": {
+    "label": "Contact phone number",
+    "hint": "For international numbers, include the country code"
+  },
+  "new-renew-countersignatory-email": {
+    "label": "Email address"
   }
 }

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -59,7 +59,10 @@
     "your-height-summary": "Why we ask for your height",
     "your-height-description": "We need to include this information in our internal database of licence holders. Your height does not affect if you can get a licence."
   },
-
+  "countersignatory-details": {
+    "header": "Countersignatory details",
+    "description": "Your countersignatory must not be a parent or relative, unless you are under 18. If you are under 18, your countersignatory must be your parent or legal guardian."
+  },
   "confirm": {
     "header": "Check your answers",
     "title": "Check your answers – Apply for an explosives precursors and poisons licence",

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -69,6 +69,9 @@
   "countersignatory-address": {
     "header": "Countersignatory address"
   },
+  "countersignatory-contact":{
+    "header": "Countersignatory's contact details"
+  },
   "confirm": {
     "header": "Check your answers",
     "title": "Check your answers – Apply for an explosives precursors and poisons licence",

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -63,6 +63,9 @@
     "header": "Countersignatory details",
     "description": "Your countersignatory must not be a parent or relative, unless you are under 18. If you are under 18, your countersignatory must be your parent or legal guardian."
   },
+  "countersignatory-address": {
+    "header": "Countersignatory address"
+  },
   "confirm": {
     "header": "Check your answers",
     "title": "Check your answers – Apply for an explosives precursors and poisons licence",
@@ -127,6 +130,24 @@
       },
       "new-renew-your-height": {
         "label": "Height (in centimetres)"
+      },
+      "new-renew-countersignatory-middlename": {
+        "label": "Middle names"
+      },
+      "new-renew-countersignatory-years":{
+        "label": "How many years have you known countersignatory?"
+      },
+      "new-renew-countersignatory-howyouknow":{
+        "label": "How do you know countersignatory?"
+      },
+      "new-renew-countersignatory-occupation":{
+        "label": "Countersignatory’s occupation"
+      },
+      "new-renew-countersignatory-address-2": {
+        "label": "Address line 2"
+      },
+      "new-renew-countersignatory-phone-number": {
+        "label": "Phone number"
       }
     },
     "complete": {

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -177,12 +177,12 @@
     "postcode" : "Enter a real UK postcode"
   },
   "new-renew-countersignatory-phone-number": {
-    "required": "Enter your telephone number",
+    "required": "Enter your countersignatory's telephone number",
     "internationalPhoneNumber": "Enter a real telephone number",
     "notUrl" : "Your answer must not include a URL"
   },
   "new-renew-countersignatory-email": {
-    "required": "Enter a contact email address",
+    "required": "Enter your countersignatory's email address",
     "email": "Enter a real email address"
   }
 }

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -154,5 +154,35 @@
     "required": "Enter your countersignatory's occupation",
     "maxlength": "Countersignatory's occupation must be 250 characters or less",
     "notUrl": "Your answer must not include a URL"
+  },
+  "new-renew-countersignatory-address-1": {
+    "required" : "Enter address line 1, typically the building and street",
+    "minlength": "Address line 1 must be between 2 and 250 characters",
+    "maxlength": "Address line 1 must be between 2 and 250 characters",
+    "notUrl" : "Your answer must not include a URL"
+  },
+  "new-renew-countersignatory-address-2": {
+    "minlength": "Address line 2 must be between 2 and 250 characters",
+    "maxlength": "Address line 2 must be between 2 and 250 characters",
+    "notUrl" : "Your answer must not include a URL"
+  },
+  "new-renew-countersignatory-town-or-city": {
+    "required" : "Enter town or city",
+    "minlength": "Town or city must be between 2 and 250 characters",
+    "maxlength": "Town or city must be between 2 and 250 characters",
+    "notUrl" : "Your answer must not include a URL"
+  },
+  "new-renew-countersignatory-postcode": {
+    "required" : "Enter a UK postcode",
+    "postcode" : "Enter a real UK postcode"
+  },
+  "new-renew-countersignatory-phone-number": {
+    "required": "Enter your telephone number",
+    "internationalPhoneNumber": "Enter a real telephone number",
+    "notUrl" : "Your answer must not include a URL"
+  },
+  "new-renew-countersignatory-email": {
+    "required": "Enter a contact email address",
+    "email": "Enter a real email address"
   }
 }

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -123,5 +123,36 @@
   },
   "new-renew-have-criminal-record": {
     "required": "Select if you have a criminal record or any type of formal warning"
+  },
+  "new-renew-countersignatory-title": {
+    "required": "Select your countersignatory's title"
+  },
+  "new-renew-countersignatory-firstname": {
+    "required": "Enter your countersignatory's first name",
+    "maxlength": "Countersignatory's first name must between 1 and 250 characters",
+    "notUrl": "Your answer must not include a URL"
+  },
+  "new-renew-countersignatory-middlename": {
+    "maxlength": "Countersignatory's middle names must be between 1 and 250 characters",
+    "notUrl": "Your answer must not include a URL"
+  },
+  "new-renew-countersignatory-lastname": {
+    "required": "Enter your countersignatory's last name",
+    "maxlength": "Countersignatory's last name must be between 1 and 250 characters",
+    "notUrl": "Your answer must not include a URL"
+  },
+  "new-renew-countersignatory-years": {
+    "required": "Select how many years you have known your countersignatory"
+
+  },
+  "new-renew-countersignatory-howyouknow": {
+    "required": "Enter how you know your countersignatory",
+    "maxlength": "How you know your countersignatory must be 250 characters or less",
+    "notUrl": "Your answer must not include a URL"
+  },
+  "new-renew-countersignatory-occupation": {
+    "required": "Enter your countersignatory's occupation",
+    "maxlength": "Countersignatory's occupation must be 250 characters or less",
+    "notUrl": "Your answer must not include a URL"
   }
 }

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -178,7 +178,7 @@
   },
   "new-renew-countersignatory-phone-number": {
     "required": "Enter your countersignatory's telephone number",
-    "internationalPhoneNumber": "Enter a real telephone number",
+    "validInternationalPhoneNumber": "Enter a real telephone number",
     "notUrl" : "Your answer must not include a URL"
   },
   "new-renew-countersignatory-email": {

--- a/apps/epp-new/views/countersignatory-details.html
+++ b/apps/epp-new/views/countersignatory-details.html
@@ -1,0 +1,11 @@
+{{<partials-page}}
+{{$page-content}}
+
+<p class="govuk-body">{{#t}}pages.countersignatory-details.description{{/t}}</p>
+
+{{#fields}}
+    {{#renderField}}{{/renderField}}
+{{/fields}}
+{{#input-submit}}continue{{/input-submit}}
+{{/page-content}}
+{{/partials-page}}

--- a/test/unit/utilities/utilities.spec.js
+++ b/test/unit/utilities/utilities.spec.js
@@ -1,7 +1,9 @@
 const {
   validLicenceNumber,
   isWithoutFullStop,
-  isValidUkDrivingLicenceNumber
+  isValidUkDrivingLicenceNumber,
+  validInternationalPhoneNumber,
+  removeWhiteSpace
 } = require('../../../utilities/helpers');
 
 describe('EPP utilities tests', () => {
@@ -51,7 +53,9 @@ describe('EPP utilities tests', () => {
       'SMITH816305DF5EW',
       'Smith816305DF5Ew'
     ];
-    input.forEach(item => expect(isValidUkDrivingLicenceNumber(item)).to.not.equal(null));
+    input.forEach(item =>
+      expect(isValidUkDrivingLicenceNumber(item)).to.not.equal(null)
+    );
   });
 
   it('isValidUkDrivingLicenceNumber- should return null for invalid format', () => {
@@ -61,6 +65,46 @@ describe('EPP utilities tests', () => {
       'STR4M382940AZ9AZ',
       '1VEET382940AZ9AZ'
     ];
-    input.forEach(item => expect(isValidUkDrivingLicenceNumber(item)).to.equal(null));
+    input.forEach(item =>
+      expect(isValidUkDrivingLicenceNumber(item)).to.equal(null)
+    );
+  });
+
+  it('.validInternationalPhoneNumber - should return false for invalid formats', () => {
+    const phoneNumbers = [
+      '123',
+      'abc',
+      'abc123',
+      '123+456',
+      '(0)+12345678',
+      '0123456789123456',
+      '0109758351',
+      'HelloWorld07777777777'
+    ];
+    phoneNumbers.forEach(
+      phoneNumber =>
+        expect(validInternationalPhoneNumber(phoneNumber)).to.be.false
+    );
+  });
+
+  it('.validInternationalPhoneNumber - should return true for valid formats', () => {
+    const phoneNumbers = [
+      '02079460000',
+      '07900000000',
+      '+442079460000',
+      '+447900000000',
+      '020 7946 0000',
+      '+44020 79460000',
+      '07 7 77 77 77 77'
+    ];
+    phoneNumbers.forEach(
+      phoneNumber =>
+        expect(validInternationalPhoneNumber(phoneNumber)).to.be.true
+    );
+  });
+
+  it('.removeWhiteSpace - should remove the whitespace', () => {
+    expect(removeWhiteSpace('Hello World')).to.equal('HelloWorld');
+    expect(removeWhiteSpace('1 2 3 4 5 ')).to.equal('12345');
   });
 });

--- a/test/unit/utilities/utilities.spec.js
+++ b/test/unit/utilities/utilities.spec.js
@@ -5,8 +5,8 @@ const {
   getKeyByValue,
   isDateOlderOrEqualTo,
   isValidUkDrivingLicenceNumber,
-    validInternationalPhoneNumber,
-    removeWhiteSpace
+  validInternationalPhoneNumber,
+  removeWhiteSpace
 } = require('../../../utilities/helpers');
 
 describe('EPP utilities tests', () => {
@@ -121,41 +121,41 @@ describe('EPP utilities tests', () => {
       expect(isValidUkDrivingLicenceNumber(item)).to.equal(null)
     );
   });
-    it('.validInternationalPhoneNumber - should return false for invalid formats', () => {
-        const phoneNumbers = [
-            '123',
-            'abc',
-            'abc123',
-            '123+456',
-            '(0)+12345678',
-            '0123456789123456',
-            '0109758351',
-            'HelloWorld07777777777'
-        ];
-        phoneNumbers.forEach(
-            phoneNumber =>
-                expect(validInternationalPhoneNumber(phoneNumber)).to.be.false
-        );
-    });
+  it('.validInternationalPhoneNumber - should return false for invalid formats', () => {
+    const phoneNumbers = [
+      '123',
+      'abc',
+      'abc123',
+      '123+456',
+      '(0)+12345678',
+      '0123456789123456',
+      '0109758351',
+      'HelloWorld07777777777'
+    ];
+    phoneNumbers.forEach(
+      phoneNumber =>
+        expect(validInternationalPhoneNumber(phoneNumber)).to.be.false
+    );
+  });
 
-    it('.validInternationalPhoneNumber - should return true for valid formats', () => {
-        const phoneNumbers = [
-            '02079460000',
-            '07900000000',
-            '+442079460000',
-            '+447900000000',
-            '020 7946 0000',
-            '+44020 79460000',
-            '07 7 77 77 77 77'
-        ];
-        phoneNumbers.forEach(
-            phoneNumber =>
-                expect(validInternationalPhoneNumber(phoneNumber)).to.be.true
-        );
-    });
+  it('.validInternationalPhoneNumber - should return true for valid formats', () => {
+    const phoneNumbers = [
+      '02079460000',
+      '07900000000',
+      '+442079460000',
+      '+447900000000',
+      '020 7946 0000',
+      '+44020 79460000',
+      '07 7 77 77 77 77'
+    ];
+    phoneNumbers.forEach(
+      phoneNumber =>
+        expect(validInternationalPhoneNumber(phoneNumber)).to.be.true
+    );
+  });
 
-    it('.removeWhiteSpace - should remove the whitespace', () => {
-        expect(removeWhiteSpace('Hello World')).to.equal('HelloWorld');
-        expect(removeWhiteSpace('1 2 3 4 5 ')).to.equal('12345');
-    });
+  it('.removeWhiteSpace - should remove the whitespace', () => {
+    expect(removeWhiteSpace('Hello World')).to.equal('HelloWorld');
+    expect(removeWhiteSpace('1 2 3 4 5 ')).to.equal('12345');
+  });
 });

--- a/utilities/helpers/index.js
+++ b/utilities/helpers/index.js
@@ -82,12 +82,12 @@ const isValidUkDrivingLicenceNumber = value =>
   value.match(/^[A-Z9]{5}\d{6}[A-Z9]{2}\d[A-Z]{2}$/i);
 
 const validInternationalPhoneNumber = value => {
-    const phoneNumberWithoutSpace = removeWhiteSpace(value);
-    const isValidPhoneNumber = validators.regex(
-        phoneNumberWithoutSpace,
-        /^\(?\+?[\d()-]{8,16}$/
-    );
-    return isValidPhoneNumber && validators.internationalPhoneNumber(value);
+  const phoneNumberWithoutSpace = removeWhiteSpace(value);
+  const isValidPhoneNumber = validators.regex(
+    phoneNumberWithoutSpace,
+    /^\(?\+?[\d()-]{8,16}$/
+  );
+  return isValidPhoneNumber && validators.internationalPhoneNumber(value);
 };
 module.exports = {
   isLicenceValid,
@@ -97,6 +97,6 @@ module.exports = {
   getKeyByValue,
   isDateOlderOrEqualTo,
   isValidUkDrivingLicenceNumber,
-    validInternationalPhoneNumber,
-   removeWhiteSpace
+  validInternationalPhoneNumber,
+  removeWhiteSpace
 };

--- a/utilities/helpers/index.js
+++ b/utilities/helpers/index.js
@@ -1,10 +1,14 @@
+const validators = require('hof/controller/validation/validators');
+
+const removeWhiteSpace = value => value?.replace(/\s+/g, '');
+
 const validLicenceNumber = value =>
   value.match(/^\d{2}[\/,\-| ]?\w[\/,\-| ]?\d{6}[\/,\-| ]?\d{4}$/);
 
 const isAlpha = str => /^[a-zA-Z]*$/.test(str);
 
 const isApplicationType = (req, value, applicationType) => {
-  if(value === applicationType) {
+  if (value === applicationType) {
     req.log('info', `Application type is ${applicationType}: ${true}`);
     return true;
   }
@@ -17,34 +21,34 @@ const isLicenceValid = req => {
   let fieldName = '';
 
   const applicationType = req.sessionModel.get('applicationType');
-  if(applicationType === 'renew') {
+  if (applicationType === 'renew') {
     licenceNumber = req.form.values['new-renew-licence-number'];
     fieldName = 'new-renew-licence-number';
   }
-  if(applicationType === 'amend') {
+  if (applicationType === 'amend') {
     licenceNumber = req.form.values['amend-licence-number'];
     fieldName = 'amend-licence-number';
   }
   const removeSpaceOrSperator = licenceNumber.replace(/[^a-zA-Z0-9]/g, '');
   const alphaValues = removeSpaceOrSperator.slice(2, 3);
 
-  if(licenceNumber.length > 16 || licenceNumber.length < 13 ) {
-    const errorMessage = 'Licence number should not be greater than 16 or less than 13';
+  if (licenceNumber.length > 16 || licenceNumber.length < 13) {
+    const errorMessage =
+      'Licence number should not be greater than 16 or less than 13';
     req.log('error', errorMessage);
 
-    return{
+    return {
       isValid: false,
       errorType: 'licence-length-restriction',
       fieldName: `${fieldName}`
     };
   }
 
-  if(!validLicenceNumber(licenceNumber) ||
-      !isAlpha(alphaValues)) {
+  if (!validLicenceNumber(licenceNumber) || !isAlpha(alphaValues)) {
     const errorMessage = `${licenceNumber} licence number not in correct format`;
     req.log('error', errorMessage);
 
-    return{
+    return {
       isValid: false,
       errorType: 'incorrect-format-licence',
       fieldName: `${fieldName}`
@@ -65,10 +69,21 @@ const isWithoutFullStop = value => {
 const isValidUkDrivingLicenceNumber = value =>
   value.match(/^[A-Z9]{5}\d{6}[A-Z9]{2}\d[A-Z]{2}$/i);
 
+const validInternationalPhoneNumber = value => {
+  const phoneNumberWithoutSpace = removeWhiteSpace(value);
+  const isValidPhoneNumber = validators.regex(
+    phoneNumberWithoutSpace,
+    /^\(?\+?[\d()-]{8,16}$/
+  );
+  return isValidPhoneNumber && validators.internationalPhoneNumber(value);
+};
+
 module.exports = {
   isLicenceValid,
   isApplicationType,
   validLicenceNumber,
   isWithoutFullStop,
-  isValidUkDrivingLicenceNumber
+  isValidUkDrivingLicenceNumber,
+  validInternationalPhoneNumber,
+  removeWhiteSpace
 };


### PR DESCRIPTION
## What? 
https://collaboration.homeoffice.gov.uk/jira/browse/EPP-91 - COUNTERSIGNATORY DETAILS page
https://collaboration.homeoffice.gov.uk/jira/browse/EPP-92 - COUNTERSIGNATORY ADDRESS page
https://collaboration.homeoffice.gov.uk/jira/browse/EPP-93 - COUNTERSIGNATORY CONTACT DETAILS page

## Why? 

EPP-91, EPP-92 & EPP-93 are combined into a single PR because they are closely related, have similar implementation logic, and don’t involve significant complexity or risk of conflicts. Grouping them together minimizes redundant reviews, and duplicate code effort. 


## How? 
- Pages are created based on the figma and ACs
- countersignatoryYears list is used from constants to show the drop down items
## Testing?
Local and branch testing
## Screenshots (optional)

![localhost_8080_new-and-renew_countersignatory-details](https://github.com/user-attachments/assets/b365a788-89b0-4aa0-bed0-12a765178c4c)

![localhost_8080_new-and-renew_countersignatory-address](https://github.com/user-attachments/assets/a6442cc4-a280-4220-9dd9-59dac9c4b80f)


![localhost_8080_new-and-renew_countersignatory-contact](https://github.com/user-attachments/assets/4c4786ca-d711-46d3-a2d9-96d366828760)


## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
