### PR TITLE
EPP-47 add identity details page new and renew

### DIFF
--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -3,9 +3,11 @@ const titles = require('../../../utilities/constants/titles');
 const countries = require('../../../utilities/constants/countries');
 const {
   isWithoutFullStop,
-  validInternationalPhoneNumber
+  validInternationalPhoneNumber,
+  isValidUkDrivingLicenceNumber
 } = require('../../../utilities/helpers');
 const countersignatoryYears = require('../../../utilities/constants/countersignatory-years');
+
 
 module.exports = {
   'new-renew-title': {
@@ -61,6 +63,40 @@ module.exports = {
     validate: ['required', 'email'],
     className: ['govuk-input'],
     labelClassName: 'govuk-label--m'
+  },
+  'new-renew-applicant-Id-type': {
+    isPageHeading: true,
+    mixin: 'radio-group',
+    validate: ['required'],
+    options: [
+      { value: 'UK-passport', toggle: 'new-renew-UK-passport-number', child: 'input-text' },
+      { value: 'EU-passport', toggle: 'new-renew-EU-passport-number', child: 'input-text' },
+      { value: 'Uk-driving-licence', toggle: 'new-renew-Uk-driving-licence-number', child: 'input-text' }
+    ]
+  },
+  'new-renew-UK-passport-number': {
+    validate: ['required', { type: 'maxlength', arguments: 9 }, 'alphanum', 'notUrl'],
+    className: ['govuk-input', 'govuk-!-width-one-thirds'],
+    dependent: {
+      field: 'new-renew-applicant-Id-type',
+      value: 'UK-passport'
+    }
+  },
+  'new-renew-EU-passport-number': {
+    validate: ['required', { type: 'maxlength', arguments: 9 }, 'alphanum', 'notUrl'],
+    className: ['govuk-input', 'govuk-!-width-one-thirds'],
+    dependent: {
+      field: 'new-renew-applicant-Id-type',
+      value: 'EU-passport'
+    }
+  },
+  'new-renew-Uk-driving-licence-number': {
+    validate: ['required', 'notUrl', { type: 'minlength', arguments: 16 }, isValidUkDrivingLicenceNumber],
+    className: ['govuk-input', 'govuk-!-width-one-thirds'],
+    dependent: {
+      field: 'new-renew-applicant-Id-type',
+      value: 'Uk-driving-licence'
+    }
   },
   'medical-declaration': {
     mixin: 'checkbox',

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -182,15 +182,32 @@ module.exports = {
       }
     },
     '/identity-details': {
-      fields: [],
-      // 3 option for next path
-      next: '/upload-british-passport',
+      fields: [
+        'new-renew-applicant-Id-type',
+        'new-renew-UK-passport-number',
+        'new-renew-EU-passport-number',
+        'new-renew-Uk-driving-licence-number'
+      ],
+      forks: [
+        {
+          target: '/upload-british-passport',
+          condition: req =>
+            req.sessionModel.get('new-renew-applicant-Id-type') === 'UK-passport'
+        },
+        {
+          target: '/upload-passport',
+          condition: req =>
+            req.sessionModel.get('new-renew-applicant-Id-type') === 'EU-passport'
+        }
+      ],
+
       locals: {
         sectionNo: {
           new: 6,
           renew: 7
         }
-      }
+      },
+      next: '/upload-driving-licence'
     },
     '/upload-british-passport': {
       fields: [],

--- a/apps/epp-new/sections/summary-data-sections.js
+++ b/apps/epp-new/sections/summary-data-sections.js
@@ -204,6 +204,26 @@ module.exports = {
       }
     ]
   },
+  'proof-of-identity': {
+    steps: [
+      {
+        step: '/identity-details',
+        field: 'new-renew-applicant-Id-type'
+      },
+      {
+        step: '/identity-details',
+        field: 'new-renew-UK-passport-number'
+      },
+      {
+        step: '/identity-details',
+        field: 'new-renew-EU-passport-number'
+      },
+      {
+        step: '/identity-details',
+        field: 'new-renew-Uk-driving-licence-number'
+      }
+    ]
+  },
   'medical-information': {
     steps: [
       {

--- a/apps/epp-new/translations/src/en/fields.json
+++ b/apps/epp-new/translations/src/en/fields.json
@@ -60,6 +60,34 @@
     "label": "Email address",
     "hint": "Where we will contact you about the outcome of your application"
   },
+  "new-renew-applicant-Id-type": {
+    "legend": "Which identity document do you want to use?",
+    "hint": "If your licence is granted, you will need to show this document when buying the substances",
+    "options": {
+      "UK-passport": {
+        "label": "British passport"
+      },
+      "EU-passport": {
+        "label": "Passport from the EU, Switzerland, Norway, Iceland or Liechtenstein"
+      },
+      "Uk-driving-licence": {
+        "label": "UK driving licence",
+        "hint": "Must be a photocard licence."
+      }
+    }
+  },
+  "new-renew-UK-passport-number": {
+    "label": "What is your passport number?",
+    "hint" : "For example, 120897A"    
+  },
+  "new-renew-EU-passport-number": {
+    "label": "What is your passport number?",
+    "hint" : "For example, 120897A"  
+  },
+  "new-renew-Uk-driving-licence-number": {
+    "label": "What is your driving licence number?",
+    "hint" : "On section 5 of your licence, for example MORGA657054SM9IJ"    
+  },
   "medical-declaration": {
     "label": "I have read and agree to this medical declaration"
   },

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -90,6 +90,9 @@
       "new-renew-contact-details": {
         "header": "Contact details"
       },
+      "proof-of-identity":{
+        "header": "Proof of identity"
+      },
       "medical-information": {
         "header": "Medical information"
       },
@@ -163,6 +166,18 @@
       },
       "new-renew-countersignatory-phone-number": {
         "label": "Phone number"
+      },
+      "new-renew-applicant-Id-type": {
+        "label": "Identification document"
+      },
+      "new-renew-UK-passport-number": {
+        "label": "British passport number"
+      },
+      "new-renew-EU-passport-number": {
+        "label": "Passport number"
+      },
+      "new-renew-Uk-driving-licence-number": {
+        "label": "Driving Licence"
       }
     },
     "complete": {

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -27,6 +27,28 @@
         "required": "Enter a contact email address",
         "email": "Enter a real email address"
     },
+    "new-renew-applicant-Id-type": {
+      "required": "Select which identity document you want to use"
+    },
+    "new-renew-UK-passport-number": {
+      "required": "Enter your passport number",
+      "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer",
+      "maxlength": "Passport number must be 9 characters or less",
+      "alphanum": "Passport number must only include numbers and letters a-z"
+      
+    },
+    "new-renew-EU-passport-number": {
+      "required": "Enter your passport number",
+      "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer", 
+      "maxlength": "Passport number must be 9 characters or less",
+      "alphanum": " Passport number must only include numbers and letters a-z"
+    },
+    "new-renew-Uk-driving-licence-number": {
+      "required": "Enter your driving licence number",
+      "isValidUkDrivingLicenceNumber": "Enter a real UK driving licence number",
+      "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer",
+      "minlength": "Driving licence number must be 16 characters"
+    }, 
     "medical-declaration": {
         "required" : "Confirm you have read and agree to this medical declaration"
     },


### PR DESCRIPTION
## What? 
create identity details page to allow user to choose which type of proof of identity wants to provide
## Why? 
as per request in jira ticket [EPP-47](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-47)
## How? 
Add new fields to 
- fields/index.js, 
- index, pages.json, 
- fields.json, 
- validation.json
## Testing?
manual test
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
