### PR TITLE
EPP-45 Upload address proof page

### DIFF
--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -162,6 +162,7 @@ module.exports = {
       }
     },
     '/upload-proof-address': {
+      // new-renew-proof-address
       fields: [],
       next: '/contact-details',
       locals: {

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -192,8 +192,11 @@ module.exports = {
       }
     },
     '/upload-proof-address': {
-      // new-renew-proof-address
-      fields: [],
+      behaviours: [
+        SaveDocument('new-renew-proof-address', 'file-upload'),
+        RemoveDocument('new-renew-proof-address')
+      ],
+      fields: ['file-upload'],
       next: '/contact-details',
       locals: {
         sectionNo: {

--- a/apps/epp-new/sections/summary-data-sections.js
+++ b/apps/epp-new/sections/summary-data-sections.js
@@ -148,6 +148,22 @@ module.exports = {
         step: '/home-address',
         field: 'new-renew-home-address-moveto-date',
         parse: date => date && dateFormatter.format(new Date(date))
+      },
+      {
+        step: '/upload-proof-address',
+        field: 'new-renew-proof-address',
+        parse: (documents, req) => {
+          if (
+            req.sessionModel
+              .get('steps')
+              .includes('/upload-proof-address') &&
+            documents?.length > 0
+          ) {
+            return documents.map(file => file?.name);
+          }
+
+          return null;
+        }
       }
     ]
   },

--- a/apps/epp-new/sections/summary-data-sections.js
+++ b/apps/epp-new/sections/summary-data-sections.js
@@ -159,7 +159,7 @@ module.exports = {
               .includes('/upload-proof-address') &&
             documents?.length > 0
           ) {
-            return documents.map(file => file?.name);
+            return documents.map(file => file?.name)?.join('\n\n');
           }
 
           return null;

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -74,8 +74,7 @@
     "upload-file": "Upload a file",
     "file-format": "Your file must be JPEG, PDF or PNG, and be 25MB or less",
     "no-file-uploaded": "No files uploaded",
-    "you-have-uploaded": "You have uploaded",
-    "files": "file(s)",
+    "files-uploaded": "Files uploaded",
     "uploading-document": "Uploading your document..."
   },
   "countersignatory-details": {
@@ -105,8 +104,7 @@
     "upload-file": "Upload a file",
     "file-format": "Your file must be JPEG, PDF or PNG, and be 25MB or less",
     "no-file-uploaded": "No files uploaded",
-    "you-have-uploaded": "You have uploaded",
-    "files": "file(s)",
+    "files-uploaded": "Files uploaded",
     "uploading-document": "Uploading your document..."
   },
   "confirm": {

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -224,6 +224,9 @@
       },
       "new-renew-british-passport": {
         "label": "Image of passport"
+      },
+      "new-renew-proof-address": {
+        "label": "Proof of address attachments"
       }
     },
     "complete": {

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -72,6 +72,27 @@
   "countersignatory-contact":{
     "header": "Countersignatory's contact details"
   },
+  "upload-proof-address": {
+    "header": "Upload proof of address",
+    "p1": "You need to scan and attach 2 documents as proof of your home address. The documents must be dated within the last 3 months and",
+    "p2": "The first document must be one of the following:",
+    "p3": "The second document must be one of the following:",
+    "p1-li1": "Mortgage statements",
+    "p1-li2": "bank or building society statement",
+    "p2-li1": "credit card statement",
+    "p2-li2": "rental agreement",
+    "p2-li3": "utilities bill (including energy, water, internet or phone bills)",
+    "p2-li4": "council tax bill",
+    "p2-li5": "benefit statement",
+    "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
+    "link-text": "signed by your countersignatory (opens in a new tab)",
+    "upload-file": "Upload a file",
+    "file-format": "Your file must be JPEG, PDF or PNG, and be 25MB or less",
+    "no-file-uploaded": "No files uploaded",
+    "you-have-uploaded": "You have uploaded",
+    "files": "file(s)",
+    "uploading-document": "Uploading your document..."
+  },
   "confirm": {
     "header": "Check your answers",
     "title": "Check your answers – Apply for an explosives precursors and poisons licence",

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -185,7 +185,8 @@
     "unsaved": "Your file could not be uploaded – try again",
     "maxFileSize": "The selected file must be 25MB or smaller",
     "fileType": "The selected file must be a JPG, PDF or PNG",
-    "maxNewRenewBritishPassport" : "You can only upload upto {{maxNewRenewBritishPassport}} files or less. Remove a file before uploading another"
+    "maxNewRenewBritishPassport" : "You can only upload upto {{maxNewRenewBritishPassport}} files or less. Remove a file before uploading another",
+    "maxNewRenewProofAddress" : "You can only upload upto {{maxNewRenewProofAddress}} files or less. Remove a file before uploading another"
   },
   "new-renew-countersignatory-title": {
     "required": "Select your countersignatory's title"

--- a/apps/epp-new/views/upload-british-passport.html
+++ b/apps/epp-new/views/upload-british-passport.html
@@ -35,7 +35,7 @@
 {{/values.new-renew-british-passport}}
 
 {{#values.new-renew-british-passport.length}}
-<h2 class="govuk-heading-m">{{#t}}pages.upload-british-passport.you-have-uploaded{{/t}} {{values.new-renew-british-passport.length}} {{#t}}pages.upload-british-passport.files{{/t}}</h2>
+<h2 class="govuk-heading-m">{{#t}}pages.upload-british-passport.files-uploaded{{/t}}</h2>
 
 <div id="uploaded-documents" class="govuk-width-container">
     {{#values.new-renew-british-passport}}

--- a/apps/epp-new/views/upload-proof-address.html
+++ b/apps/epp-new/views/upload-proof-address.html
@@ -48,7 +48,7 @@
 {{/values.new-renew-proof-address}}
 
 {{#values.new-renew-proof-address.length}}
-<h2 class="govuk-heading-m">{{#t}}pages.upload-proof-address.you-have-uploaded{{/t}} {{values.new-renew-proof-address.length}} {{#t}}pages.upload-proof-address.files{{/t}}</h2>
+<h2 class="govuk-heading-m">{{#t}}pages.upload-proof-address.files-uploaded{{/t}}</h2>
 
 <div id="uploaded-documents" class="govuk-width-container">
     {{#values.new-renew-proof-address}}

--- a/apps/epp-new/views/upload-proof-address.html
+++ b/apps/epp-new/views/upload-proof-address.html
@@ -1,0 +1,75 @@
+{{<partials-page}} {{$encoding}}enctype="multipart/form-data" name="file-upload-form" {{/encoding}}
+{{$page-content}}
+<p class="govuk-body">{{#t}}pages.upload-proof-address.p1{{/t}}
+    <a class="govuk-link" href="{{#t}}pages.upload-proof-address.link{{/t}}" target="_blank" rel="noreferrer noopener">
+        {{#t}}pages.upload-proof-address.link-text{{/t}}
+    </a>
+</p>
+
+<p class="govuk-body">{{#t}}pages.upload-proof-address.p2{{/t}}</p>
+
+<ul class="govuk-!-margin-top-2 govuk-!-margin-left-2">
+    <li>{{#t}}pages.upload-proof-address.p1-li1{{/t}}</li>
+    <li>{{#t}}pages.upload-proof-address.p1-li2{{/t}}</li>
+  </ul>
+
+<p class="govuk-body">{{#t}}pages.upload-proof-address.p3{{/t}}</p>
+
+<ul class="govuk-!-margin-top-2 govuk-!-margin-left-2">
+    <li>{{#t}}pages.upload-proof-address.p2-li1{{/t}}</li>
+    <li>{{#t}}pages.upload-proof-address.p2-li2{{/t}}</li>
+    <li>{{#t}}pages.upload-proof-address.p2-li3{{/t}}</li>
+    <li>{{#t}}pages.upload-proof-address.p2-li4{{/t}}</li>
+    <li>{{#t}}pages.upload-proof-address.p2-li5{{/t}}</li>
+</ul>
+
+<div class="govuk-form-group" id="hofFileUpload">
+    <label class="govuk-label" for="file-upload">
+        <h2>{{#t}}pages.upload-proof-address.upload-file{{/t}}</h2>
+        <span class="govuk-hint">{{#t}}pages.upload-proof-address.file-format{{/t}}</span>
+    </label>
+    <p id="file-upload-error-maxFileSize" class="govuk-error-message govuk-!-display-none">
+        <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.maxFileSize{{/t}}
+    </p>
+    <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
+        <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
+    </p>
+    <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="new-renew-proof-address">
+
+    <div id="upload-page-loading-spinner" class="spinner-container">
+        <div class="spinner-loader"></div>
+        <span class="spinner-message">{{#t}}pages.upload-proof-address.uploading-document{{/t}}</span>
+    </div>
+
+</div>
+
+{{^values.new-renew-proof-address}}
+<h2 class="govuk-heading-m">{{#t}}pages.upload-proof-address.no-file-uploaded{{/t}}</h2>
+{{/values.new-renew-proof-address}}
+
+{{#values.new-renew-proof-address.length}}
+<h2 class="govuk-heading-m">{{#t}}pages.upload-proof-address.you-have-uploaded{{/t}} {{values.new-renew-proof-address.length}} {{#t}}pages.upload-proof-address.files{{/t}}</h2>
+
+<div id="uploaded-documents" class="govuk-width-container">
+    {{#values.new-renew-proof-address}}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+            {{name}}
+        </div>
+        <div class="govuk-grid-column-one-quarter">
+            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+        </div>
+    </div>
+    <div class="file-upload-hrline"></div>
+    {{/values.new-renew-proof-address}}
+</div>
+
+{{/values.new-renew-proof-address.length}}
+
+
+<button class="govuk-button" name="requireFileUpload" value="new-renew-proof-address">
+    {{#t}}buttons.continue{{/t}}
+</button>
+
+{{/page-content}}
+{{/partials-page}}

--- a/config.js
+++ b/config.js
@@ -66,11 +66,11 @@ module.exports = {
         limit: 1,
         limitValidationError: 'maxAmendBritishPassport'
       },
-    'new-renew-proof-address': {
+      'new-renew-proof-address': {
         allowMultipleUploads: true,
         limit: 2,
         limitValidationError: 'maxNewRenewProofAddress'
-        }
+      }
     }
   },
   sectionDetails: {

--- a/config.js
+++ b/config.js
@@ -71,11 +71,11 @@ module.exports = {
         limit: 1,
         limitValidationError: 'maxNewRenewEuPassport'
       },
-    'new-renew-proof-address': {
+      'new-renew-proof-address': {
         allowMultipleUploads: true,
         limit: 2,
         limitValidationError: 'maxNewRenewProofAddress'
-    }
+      }
     }
   },
   sectionDetails: {

--- a/config.js
+++ b/config.js
@@ -60,6 +60,11 @@ module.exports = {
         allowMultipleUploads: false,
         limit: 1,
         limitValidationError: 'maxNewRenewBritishPassport'
+      },
+      'new-renew-proof-address': {
+        allowMultipleUploads: true,
+        limit: 2,
+        limitValidationError: 'maxNewRenewProofAddress'
       }
     }
   },


### PR DESCRIPTION
## What? 
[EPP-45](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-45) - New & Renew - Create a UPLOAD PROOF OF ADDRESS page
## Why? 

Created upload proof of address page so users can upload their proof of address
## How? 

## Testing?
Local and branch testing
## Screenshots (optional)
![epp-epp-45-proof-of-address-page internal branch sas-notprod homeoffice gov uk_new-and-renew_upload-proof-address](https://github.com/user-attachments/assets/0a7d2a3f-5a0d-46e3-9317-a8b552041778)

![Screenshot 2025-02-10 at 13 35 18](https://github.com/user-attachments/assets/2269960c-e478-41ec-8042-dc1acc1bb004)


## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
