### PR TITLE
EPP-41 Create previous address page

### DIFF
--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -394,6 +394,74 @@ module.exports = {
       validate: ['required', 'date', 'before']
     }
   ),
+  'new-renew-previous-home-address-line1': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds'],
+    validate: [
+      'required',
+      { type: 'minlength', arguments: 2 },
+      { type: 'maxlength', arguments: 250 },
+      'notUrl'
+    ]
+  },
+  'new-renew-previous-home-address-line2': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds'],
+    validate: [
+      { type: 'minlength', arguments: 2 },
+      { type: 'maxlength', arguments: 250 },
+      'notUrl'
+    ]
+  },
+  'new-renew-previous-home-address-town': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds'],
+    validate: [
+      'required',
+      { type: 'minlength', arguments: 2 },
+      { type: 'maxlength', arguments: 250 },
+      'notUrl'
+    ]
+  },
+  'new-renew-previous-home-address-county': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds'],
+    validate: [
+      { type: 'minlength', arguments: 2 },
+      { type: 'maxlength', arguments: 250 },
+      'notUrl'
+    ]
+  },
+  'new-renew-previous-home-address-postcode': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-input', 'govuk-!-width-two-thirds'],
+    formatter: ['ukPostcode']
+  },
+  'new-renew-previous-home-address-country': {
+    mixin: 'select',
+    validate: ['required'],
+    labelClassName: 'govuk-label--s',
+    className: ['govuk-!-width-two-thirds'],
+    options: [
+      {
+        value: '',
+        label: 'fields.new-renew-previous-home-address-country.options.none_selected'
+      }
+    ].concat(countries)
+  },
+  'new-renew-previous-home-address-moveto-date': dateComponent(
+    'new-renew-previous-home-address-moveto-date',
+    {
+      mixin: 'input-date',
+      legend: { className: 'bold' },
+      validate: ['required', 'date', 'before']
+    }
+  ),
   'new-renew-countersignatory-title': {
     mixin: 'select',
     validate: 'required',

--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -371,14 +371,14 @@ module.exports = {
   'new-renew-home-address-postcode': {
     mixin: 'input-text',
     labelClassName: 'govuk-label--s',
-    className: ['govuk-input', 'govuk-!-width-two-thirds'],
+    className: ['govuk-input', 'govuk-input--width-10'],
     formatter: ['ukPostcode']
   },
   'new-renew-home-address-country': {
     mixin: 'select',
     validate: ['required'],
     labelClassName: 'govuk-label--s',
-    className: ['govuk-!-width-two-thirds'],
+    className: ['typeahead'],
     options: [
       {
         value: '',
@@ -397,7 +397,6 @@ module.exports = {
   'new-renew-previous-home-address-line1': {
     mixin: 'input-text',
     labelClassName: 'govuk-label--s',
-    className: ['govuk-input', 'govuk-!-width-two-thirds'],
     validate: [
       'required',
       { type: 'minlength', arguments: 2 },
@@ -408,7 +407,6 @@ module.exports = {
   'new-renew-previous-home-address-line2': {
     mixin: 'input-text',
     labelClassName: 'govuk-label--s',
-    className: ['govuk-input', 'govuk-!-width-two-thirds'],
     validate: [
       { type: 'minlength', arguments: 2 },
       { type: 'maxlength', arguments: 250 },
@@ -418,7 +416,6 @@ module.exports = {
   'new-renew-previous-home-address-town': {
     mixin: 'input-text',
     labelClassName: 'govuk-label--s',
-    className: ['govuk-input', 'govuk-!-width-two-thirds'],
     validate: [
       'required',
       { type: 'minlength', arguments: 2 },
@@ -429,7 +426,6 @@ module.exports = {
   'new-renew-previous-home-address-county': {
     mixin: 'input-text',
     labelClassName: 'govuk-label--s',
-    className: ['govuk-input', 'govuk-!-width-two-thirds'],
     validate: [
       { type: 'minlength', arguments: 2 },
       { type: 'maxlength', arguments: 250 },
@@ -439,14 +435,14 @@ module.exports = {
   'new-renew-previous-home-address-postcode': {
     mixin: 'input-text',
     labelClassName: 'govuk-label--s',
-    className: ['govuk-input', 'govuk-!-width-two-thirds'],
+    className: ['govuk-input', 'govuk-input--width-10'],
     formatter: ['ukPostcode']
   },
   'new-renew-previous-home-address-country': {
     mixin: 'select',
     validate: ['required'],
     labelClassName: 'govuk-label--s',
-    className: ['govuk-!-width-two-thirds'],
+    className: ['typeahead'],
     options: [
       {
         value: '',

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -129,6 +129,7 @@ module.exports = {
       forks: [
         {
           target: '/upload-proof-address',
+
           condition: req => {
             const moveToDate =
               req.form.values['new-renew-home-address-moveto-date'];
@@ -145,7 +146,16 @@ module.exports = {
       }
     },
     '/previous-address': {
-      fields: [],
+      behaviours: [PostcodeValidation],
+      fields: [
+        'new-renew-previous-home-address-line1',
+        'new-renew-previous-home-address-line2',
+        'new-renew-previous-home-address-town',
+        'new-renew-previous-home-address-county',
+        'new-renew-previous-home-address-postcode',
+        'new-renew-previous-home-address-country',
+        'new-renew-previous-home-address-moveto-date'
+      ],
       next: '/previous-addresses',
       locals: {
         sectionNo: {

--- a/apps/epp-new/translations/src/en/fields.json
+++ b/apps/epp-new/translations/src/en/fields.json
@@ -252,6 +252,33 @@
     "legend": "When did you move to this address?",
     "hint": "For example, 30 10 2014"
   },
+  "new-renew-previous-home-address-line1": {
+    "label": "Address line 1"
+  },
+  "new-renew-previous-home-address-line2": {
+    "label": "Address line 2 (optional)"
+  },
+  "new-renew-previous-home-address-town": {
+    "label": "Town or city"
+  },
+  "new-renew-previous-home-address-county": {
+    "label": "County, state, province (optional)"
+  },
+  "new-renew-previous-home-address-postcode": {
+    "label": "Postcode (optional)",
+    "hint": "Postcode is optional if your address is outside the UK"
+  },
+  "new-renew-previous-home-address-country": {
+    "label": "Country of address",
+    "hint": "Select a country from the list",
+    "options": {
+      "none_selected": "Select"
+    }
+  },
+  "new-renew-previous-home-address-moveto-date": {
+    "legend": "When did you move to this address?",
+    "hint": "For example, 30 10 2014"
+  },
   "new-renew-countersignatory-title":{
     "label": "Title",
     "options": {

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -21,6 +21,9 @@
   "home-address": {
     "header": "What is your home address?"
   },
+  "previous-address": {
+    "header": "Previous address"
+  },
   "contact-details": {
     "title": "What are your contact details?",
     "header": "What are your contact details?"
@@ -159,6 +162,12 @@
         "label": "Country"
       },
       "new-renew-home-address-moveto-date": {
+        "label": "Moved date"
+      },
+      "new-renew-previous-home-address-country": {
+        "label": "Country"
+      },
+      "new-renew-previous-home-address-moveto-date": {
         "label": "Moved date"
       },
       "new-renew-countersignatory-middlename": {

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -187,6 +187,40 @@
     "fileType": "The selected file must be a JPG, PDF or PNG",
     "maxNewRenewBritishPassport" : "You can only upload upto {{maxNewRenewBritishPassport}} files or less. Remove a file before uploading another"
   },
+  "new-renew-previous-home-address-line1": {
+    "required": "Enter address line 1, typically the building and street",
+    "minlength": "Address line 1 must be between 2 and 250 characters",
+    "maxlength": "Address line 1 must be between 2 and 250 characters",
+    "notUrl": "Your answer must not include a URL"
+  },
+  "new-renew-previous-home-address-line2": {
+    "minlength": "Address line 2 must be between 2 and 250 characters",
+    "maxlength": "Address line 2 must be between 2 and 250 characters",
+    "notUrl": "Your answer must not include a URL"
+  },
+  "new-renew-previous-home-address-town": {
+    "required": "Enter town or city",
+    "minlength": "Town or city must be between 2 and 250 characters",
+    "maxlength": "Town or city must be between 2 and 250 characters",
+    "notUrl": "Your answer must not include a URL"
+  },
+  "new-renew-previous-home-address-county": {
+    "minlength": "County, state or province must be between 2 and 250 characters",
+    "maxlength": "County, state or province must be between 2 and 250 characters",
+    "notUrl": "Your answer must not include a URL"
+  },
+  "new-renew-previous-home-address-postcode": {
+    "required": "Enter a UK postcode",
+    "postcode": "Enter a real UK postcode"
+  },
+  "new-renew-previous-home-address-country": {
+    "required": "Select a country of address"
+  },
+  "new-renew-previous-home-address-moveto-date": {
+    "required": "Enter a date you moved to this address",
+    "date": "Enter a real date",
+    "before": "Date you moved to this address must be in the past"
+  },
   "new-renew-countersignatory-title": {
     "required": "Select your countersignatory's title"
   },

--- a/config.js
+++ b/config.js
@@ -70,6 +70,7 @@ module.exports = {
   postCodeCountriesMap: {
     'amend-postcode': 'amend-country',
     'new-renew-home-address-postcode': 'new-renew-home-address-country',
+    'new-renew-previous-home-address-postcode': 'new-renew-previous-home-address-country',
     'amend-new-postcode': 'amend-new-country'
   }
 };


### PR DESCRIPTION
## What? 
[EPP-41](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-41) - Create previous address page for new & renew flow - EPP

## Why? 
Allows user to add a previous address

## How? 
- Added Heading and radio buttons for page
- Added validations for page

## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
