### PR TITLE
EPP-102 Amend path UPLOAD BRITISH PASSPORT

### DIFF
--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -4,7 +4,8 @@ const ValidateLicenceNumber = require('../epp-common/behaviours/licence-validato
 const PostcodeValidation = require('../../utilities/helpers//postcode-validation');
 const RemoveEditMode = require('../epp-common/behaviours/remove-edit-mode');
 const AfterDateOfBirth = require('../epp-common/behaviours/after-date-validator');
-
+const SaveDocument = require('../epp-common/behaviours/save-document');
+const RemoveDocument = require('../epp-common/behaviours/remove-document');
 module.exports = {
   name: 'EPP form',
   fields: 'apps/epp-amend/fields',
@@ -110,6 +111,9 @@ module.exports = {
       next: '/upload-driving-licence'
     },
     '/upload-british-passport': {
+      behaviours: [SaveDocument('amend-british-passport', 'file-upload'), RemoveDocument('amend-british-passport')],
+      fields: ['file-upload'],
+      continueOnEdit: true,
       next: '/change-home-address',
       locals: { captionHeading: 'Section 9 of 20' }
     },

--- a/apps/epp-amend/sections/summary-data-sections.js
+++ b/apps/epp-amend/sections/summary-data-sections.js
@@ -129,7 +129,24 @@ module.exports = {
       {
         step: '/identity-details',
         field: 'amend-Uk-driving-licence-number'
+      },
+      {
+        step: '/upload-british-passport',
+        field: 'amend-british-passport',
+        parse: (documents, req) => {
+          if (
+            req.sessionModel
+              .get('steps')
+              .includes('/upload-british-passport') &&
+            documents?.length > 0
+          ) {
+            return documents.map(file => file.name);
+          }
+
+          return null;
+        }
       }
+
     ]
   },
   'amend-home-address-options': {

--- a/apps/epp-amend/translations/src/en/buttons.json
+++ b/apps/epp-amend/translations/src/en/buttons.json
@@ -1,3 +1,5 @@
 {
-"start": "initial button"
+"start": "initial button",
+"remove": "Remove",
+"continue": "Continue"
 }

--- a/apps/epp-amend/translations/src/en/fields.json
+++ b/apps/epp-amend/translations/src/en/fields.json
@@ -110,6 +110,7 @@
     "label": "What is your driving licence number?",
     "hint" : "On section 5 of your licence, for example MORGA657054SM9IJ"    
   },
+ 
   "amend-home-address-options": {
     "legend": "Do you need to amend your home address on the licence?",
     "options": {

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -28,6 +28,17 @@
   "new-address": {
     "header": "What is your new address?"
   },
+  "upload-british-passport" : {
+    "header": "Upload British passport",
+    "label": "Upload a file",
+    "hint": "Your file must be JPEG, PDF or PNG and be 25MB or less",
+    "paragraph1": "Attach an image of your British passport as proof of your identity. the image must be",
+    "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
+    "link-text" : "signed by your countersignatory (opens in a new tab).",
+    "uploading-document": "Document uploading",
+    "not-uploaded": "No files uploaded", 
+    "uploaded": "File uploaded" 
+  },
   "select-precursor": {
     "header": "Explosives precursors",
     "p1": "Tell us which explosives precursors you want to import acquire use or possess.",
@@ -131,6 +142,9 @@
       },
       "amend-Uk-driving-licence-number": {
         "label": "Driving Licence"
+      },
+      "amend-british-passport" : {
+        "label": "British passport attachment"
       },
       "amend-new-country": {
         "label": "Country"

--- a/apps/epp-amend/translations/src/en/validation.json
+++ b/apps/epp-amend/translations/src/en/validation.json
@@ -89,6 +89,12 @@
         "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer",
         "minlength": "Driving licence number must be 16 characters"
       }, 
+      "file-upload": {
+        "required": "Select a file to upload",
+        "maxFileSize": "The selected file must 25MB or smaller",
+        "fileType": "The selected file must be a JPG, PDF or PNG",
+        "maxAmendBritishPassport": "You can only upload up to {{maxAmendBritishPassport}} files or less. Remove a file before uploading another "
+      },
     "amend-new-name-title": {
         "required" : "Select the title of your new name"
     },

--- a/apps/epp-amend/views/upload-british-passport.html
+++ b/apps/epp-amend/views/upload-british-passport.html
@@ -1,0 +1,48 @@
+{{<partials-page}}
+{{$encoding}}enctype="multipart/form-data" name="file-upload-form" {{/encoding}}
+{{$page-content}}
+<p>{{#t}}pages.upload-british-passport.paragraph1{{/t}}
+   <a class="govuk-link" href="{{#t}}pages.upload-british-passport.link{{/t}}" rel="noreferrer noopener" target="_blank">{{#t}}pages.upload-british-passport.link-text{{/t}}</a>
+</p>
+<div class="govuk-form-group" id="hofFileUpload">
+   <label class="govuk-label" for="file-upload">
+      <h2>{{#t}}pages.upload-british-passport.label{{/t}}</h2>
+      <span class="govuk-hint">{{#t}}pages.upload-british-passport.hint{{/t}}</span>
+   </label>
+   <p id="file-upload-error-maxFileSize" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.maxFileSize{{/t}}
+   </p>
+   <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
+   </p>
+   <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="amend-british-passport">
+   <div id="upload-page-loading-spinner" class="spinner-container">
+      <div class="spinner-loader"></div>
+      <span class="spinner-message">{{#t}}pages.upload-british-passport.uploading-document{{/t}}</span>
+   </div>
+</div>
+{{^values.amend-british-passport}}
+<h2 class="govuk-heading-m">{{#t}}pages.upload-british-passport.not-uploaded{{/t}}</h2>
+{{/values.amend-british-passport}}
+{{#values.amend-british-passport.length}}
+<br>
+<h2 class="govuk-heading-m">{{#t}}pages.upload-british-passport.uploaded{{/t}}</h2>
+<div id="uploaded-documents" class="govuk-width-container">
+   {{#values.amend-british-passport}}
+   <div class="govuk-grid-row">
+       <div class="govuk-grid-column-three-quarters">
+           {{name}}
+       </div>
+       <div class="govuk-grid-column-one-quarter">
+           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+       </div>
+   </div>
+   <div class="file-upload-hrline"></div>
+   {{/values.amend-british-passport}}
+</div>
+{{/values.amend-british-passport.length}}
+<button class="govuk-button" name="requireFileUpload" value="amend-british-passport">
+   {{#t}}buttons.continue{{/t}}
+</button>
+{{/page-content}}
+{{/partials-page}}

--- a/config.js
+++ b/config.js
@@ -60,6 +60,11 @@ module.exports = {
         allowMultipleUploads: false,
         limit: 1,
         limitValidationError: 'maxNewRenewBritishPassport'
+      },
+      'amend-british-passport': {
+        allowMultipleUploads: false,
+        limit: 1,
+        limitValidationError: 'maxAmendBritishPassport'
       }
     }
   },


### PR DESCRIPTION
## What? 
Add British passport upload page as per jira ticket request [EPP-102](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-102)
## Why? 
to give the user the possibility to upload their proof of identity
## How? 

- add field for upload input in:
- summary-data-sections.js
- buttons.json
- field.json
- pages.json
- validation.json
- upload-british-passport.html
- add limitation in config.js file
- add button
## Testing?
n/a
## Screenshots (optional)
## Anything Else? (optional)
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
