### PR TITLE
EPP-50 create upload driving licence page

### DIFF
--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -274,7 +274,11 @@ module.exports = {
       }
     },
     '/upload-driving-licence': {
-      fields: [],
+      behaviours: [
+        SaveDocument('new-renew-upload-driving-licence', 'file-upload'),
+        RemoveDocument('new-renew-upload-driving-licence')
+      ],
+      fields: ['file-upload'],
       next: '/other-licences',
       locals: {
         sectionNo: {

--- a/apps/epp-new/sections/summary-data-sections.js
+++ b/apps/epp-new/sections/summary-data-sections.js
@@ -194,22 +194,6 @@ module.exports = {
         field: 'new-renew-applicant-Id-type'
       },
       {
-        step: '/upload-driving-licence',
-        field: 'new-renew-upload-driving-licence',
-        parse: (documents, req) => {
-          if (
-            req.sessionModel
-              .get('steps')
-              .includes('/upload-upload-driving-licence') &&
-            documents?.length > 0
-          ) {
-            return documents.map(file => file.name);
-          }
-
-          return null;
-        }
-      },
-      {
         step: '/identity-details',
         field: 'new-renew-UK-passport-number'
       },
@@ -229,6 +213,20 @@ module.exports = {
             req.sessionModel
               .get('steps')
               .includes('/upload-british-passport') &&
+            documents?.length > 0
+          ) {
+            return documents.map(file => file.name);
+          }
+
+          return null;
+        }
+      },
+      {
+        step: '/upload-driving-licence',
+        field: 'new-renew-upload-driving-licence',
+        parse: (documents, req) => {
+          if (
+            req.sessionModel.get('steps').includes('/upload-driving-licence') &&
             documents?.length > 0
           ) {
             return documents.map(file => file.name);

--- a/apps/epp-new/sections/summary-data-sections.js
+++ b/apps/epp-new/sections/summary-data-sections.js
@@ -194,6 +194,22 @@ module.exports = {
         field: 'new-renew-applicant-Id-type'
       },
       {
+        step: '/upload-driving-licence',
+        field: 'new-renew-upload-driving-licence',
+        parse: (documents, req) => {
+          if (
+            req.sessionModel
+              .get('steps')
+              .includes('/upload-upload-driving-licence') &&
+            documents?.length > 0
+          ) {
+            return documents.map(file => file.name);
+          }
+
+          return null;
+        }
+      },
+      {
         step: '/identity-details',
         field: 'new-renew-UK-passport-number'
       },

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -77,7 +77,8 @@
     "upload-file": "Upload a file",
     "file-format": "Your file must be JPEG, PDF or PNG, and be 25MB or less",
     "no-file-uploaded": "No files uploaded",
-    "files-uploaded": "Files uploaded",
+    "you-have-uploaded": "You have uploaded",
+    "files": "file(s)",
     "uploading-document": "Uploading your document..."
   },
   "countersignatory-details": {
@@ -93,13 +94,12 @@
   "upload-driving-licence": {
     "header": "Upload UK driving licence",
     "p1": "Attach an image of your driving licence photocard as proof of your identity. The image must be",
-    "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned ",
+    "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
     "link-text": "signed by your countersignatory (opens in a new tab)",
     "upload-file": "Upload a file",
     "file-format": "Your file must be JPEG, PDF or PNG, and be 25MB or less",
     "no-file-uploaded": "No files uploaded",
-    "you-have-uploaded": "You have uploaded",
-    "files": "file(s)",
+    "files-uploaded": "Files uploaded",
     "uploading-document": "Uploading your document..."
   },
   "confirm": {
@@ -219,10 +219,13 @@
         "label": "Passport number"
       },
       "new-renew-Uk-driving-licence-number": {
-        "label": "UK driving licence"
+        "label": "Driving Licence"
       },
       "new-renew-british-passport": {
         "label": "Image of passport"
+      },
+      "new-renew-upload-driving-licence": {
+        "label": "UK driving licence attachment"
       }
     },
     "complete": {

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -91,6 +91,18 @@
   "countersignatory-contact":{
     "header": "Countersignatory's contact details"
   },
+  "upload-driving-licence": {
+    "header": "Upload UK driving licence",
+    "p1": "Attach an image of your British passport as proof of your identity. The image must be",
+    "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned ",
+    "link-text": "signed by your countersignatory (opens in a new tab)",
+    "upload-file": "Upload a file",
+    "file-format": "Your file must be JPEG, PDF or PNG, and be 25MB or less",
+    "no-file-uploaded": "No files uploaded",
+    "you-have-uploaded": "You have uploaded",
+    "files": "file(s)",
+    "uploading-document": "Uploading your document..."
+  },
   "confirm": {
     "header": "Check your answers",
     "title": "Check your answers – Apply for an explosives precursors and poisons licence",

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -77,8 +77,7 @@
     "upload-file": "Upload a file",
     "file-format": "Your file must be JPEG, PDF or PNG, and be 25MB or less",
     "no-file-uploaded": "No files uploaded",
-    "you-have-uploaded": "You have uploaded",
-    "files": "file(s)",
+    "files-uploaded": "Files uploaded",
     "uploading-document": "Uploading your document..."
   },
   "countersignatory-details": {
@@ -93,7 +92,7 @@
   },
   "upload-driving-licence": {
     "header": "Upload UK driving licence",
-    "p1": "Attach an image of your British passport as proof of your identity. The image must be",
+    "p1": "Attach an image of your driving licence photocard as proof of your identity. The image must be",
     "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned ",
     "link-text": "signed by your countersignatory (opens in a new tab)",
     "upload-file": "Upload a file",
@@ -220,7 +219,7 @@
         "label": "Passport number"
       },
       "new-renew-Uk-driving-licence-number": {
-        "label": "Driving Licence"
+        "label": "UK driving licence"
       },
       "new-renew-british-passport": {
         "label": "Image of passport"

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -185,7 +185,8 @@
     "unsaved": "Your file could not be uploaded – try again",
     "maxFileSize": "The selected file must be 25MB or smaller",
     "fileType": "The selected file must be a JPG, PDF or PNG",
-    "maxNewRenewBritishPassport" : "You can only upload upto {{maxNewRenewBritishPassport}} files or less. Remove a file before uploading another"
+    "maxNewRenewBritishPassport" : "You can only upload upto {{maxNewRenewBritishPassport}} files or less. Remove a file before uploading another",
+    "maxNewRenewDrivingLicence" : "You can only upload upto {{maxNewRenewDrivingLicence}} files or less. Remove a file before uploading another"
   },
   "new-renew-previous-home-address-line1": {
     "required": "Enter address line 1, typically the building and street",

--- a/apps/epp-new/views/upload-driving-licence.html
+++ b/apps/epp-new/views/upload-driving-licence.html
@@ -1,0 +1,62 @@
+{{<partials-page}} {{$encoding}}enctype="multipart/form-data" name="file-upload-form" {{/encoding}} 
+{{$page-content}}
+<p class="govuk-body">{{#t}}pages.upload-driving-licence.p1{{/t}} 
+    <a 
+        class="govuk-link" 
+        href="{{#t}}pages.upload-driving-licence.link{{/t}}" 
+        target="_blank"
+        rel="noreferrer noopener">
+    {{#t}}pages.upload-driving-licence.link-text{{/t}}
+    </a>
+</p>
+
+<div class="govuk-form-group" id="hofFileUpload">
+    <label class="govuk-label" for="file-upload">
+        <h2>{{#t}}pages.upload-driving-licence.upload-file{{/t}}</h2>
+        <span class="govuk-hint">{{#t}}pages.upload-driving-licence.file-format{{/t}}</span>
+    </label>
+    <p id="file-upload-error-maxFileSize" class="govuk-error-message govuk-!-display-none">
+        <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.maxFileSize{{/t}}
+    </p>
+    <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
+        <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
+    </p>
+    <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="new-renew-upload-driving-licence">
+
+    <div id="upload-page-loading-spinner" class="spinner-container">
+        <div class="spinner-loader"></div>
+        <span class="spinner-message">{{#t}}pages.upload-driving-licence.uploading-document{{/t}}</span>
+      </div>
+
+</div>
+
+{{^values.new-renew-upload-driving-licence}}
+<h2 class="govuk-heading-m">{{#t}}pages.upload-driving-licence.no-file-uploaded{{/t}}</h2>
+{{/values.new-renew-upload-driving-licence}}
+
+{{#values.new-renew-upload-driving-licence.length}}
+<h2 class="govuk-heading-m">{{#t}}pages.upload-driving-licence.you-have-uploaded{{/t}} {{values.new-renew-upload-driving-licence.length}} {{#t}}pages.upload-driving-licence.files{{/t}}</h2>
+
+<div id="uploaded-documents" class="govuk-width-container">
+    {{#values.new-renew-upload-driving-licence}}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+            {{name}}
+        </div>
+        <div class="govuk-grid-column-one-quarter">
+            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+        </div>
+    </div>
+    <div class="file-upload-hrline"></div>
+    {{/values.new-renew-upload-driving-licence}}
+</div>
+
+{{/values.new-renew-upload-driving-licence.length}}
+
+
+<button class="govuk-button" name="requireFileUpload" value="new-renew-upload-driving-licence">
+    {{#t}}buttons.continue{{/t}}
+</button>
+
+{{/page-content}}
+{{/partials-page}}

--- a/apps/epp-new/views/upload-driving-licence.html
+++ b/apps/epp-new/views/upload-driving-licence.html
@@ -35,7 +35,7 @@
 {{/values.new-renew-upload-driving-licence}}
 
 {{#values.new-renew-upload-driving-licence.length}}
-<h2 class="govuk-heading-m">{{#t}}pages.upload-driving-licence.upload-file{{/t}}</h2>
+<h2 class="govuk-heading-m">{{#t}}pages.upload-driving-licence.files-uploaded{{/t}}</h2>
 
 <div id="uploaded-documents" class="govuk-width-container">
     {{#values.new-renew-upload-driving-licence}}

--- a/apps/epp-new/views/upload-driving-licence.html
+++ b/apps/epp-new/views/upload-driving-licence.html
@@ -35,7 +35,7 @@
 {{/values.new-renew-upload-driving-licence}}
 
 {{#values.new-renew-upload-driving-licence.length}}
-<h2 class="govuk-heading-m">{{#t}}pages.upload-driving-licence.you-have-uploaded{{/t}} {{values.new-renew-upload-driving-licence.length}} {{#t}}pages.upload-driving-licence.files{{/t}}</h2>
+<h2 class="govuk-heading-m">{{#t}}pages.upload-driving-licence.upload-file{{/t}}</h2>
 
 <div id="uploaded-documents" class="govuk-width-container">
     {{#values.new-renew-upload-driving-licence}}

--- a/config.js
+++ b/config.js
@@ -65,6 +65,11 @@ module.exports = {
         allowMultipleUploads: false,
         limit: 1,
         limitValidationError: 'maxAmendBritishPassport'
+      },
+      'new-renew-upload-driving-licence': {
+        allowMultipleUploads: false,
+        limit: 1,
+        limitValidationError: 'maxNewRenewDrivingLicence'
       }
     }
   },

--- a/config.js
+++ b/config.js
@@ -71,11 +71,11 @@ module.exports = {
         limit: 1,
         limitValidationError: 'maxNewRenewEuPassport'
       },
-        'new-renew-upload-driving-licence': {
-            allowMultipleUploads: false,
-            limit: 1,
-            limitValidationError: 'maxNewRenewDrivingLicence'
-        }
+      'new-renew-upload-driving-licence': {
+        allowMultipleUploads: false,
+        limit: 1,
+        limitValidationError: 'maxNewRenewDrivingLicence'
+      }
     }
   },
   sectionDetails: {


### PR DESCRIPTION
## What? 
[EPP-50](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-50) - Create upload driving licence page for new & renew flow - EPP

## Why? 
Allows user to upload a form of identification (driving licence)

## How? 
- implementation of upload functionality
- Added validations for page

## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging