### PR TITLE
EPP-104 UPLOAD UK DRIVING LICENCE

### DIFF
--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -125,6 +125,8 @@ module.exports = {
       locals: { captionHeading: 'Section 9 of 23' }
     },
     '/upload-driving-licence': {
+      behaviours: [SaveDocument('amend-uk-driving-licence', 'file-upload'), RemoveDocument('amend-uk-driving-licence')],
+      fields: ['file-upload'],
       next: '/change-home-address',
       locals: { captionHeading: 'Section 9 of 23' }
     },

--- a/apps/epp-amend/sections/summary-data-sections.js
+++ b/apps/epp-amend/sections/summary-data-sections.js
@@ -161,6 +161,22 @@ module.exports = {
 
           return null;
         }
+      },
+      {
+        step: '/upload-driving-licence',
+        field: 'amend-uk-driving-licence',
+        parse: (documents, req) => {
+          if (
+            req.sessionModel
+              .get('steps')
+              .includes('/upload-driving-licence') &&
+            documents?.length > 0
+          ) {
+            return documents.map(file => file.name);
+          }
+
+          return null;
+        }
       }
     ]
   },

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -28,18 +28,18 @@
   "new-address": {
     "header": "What is your new address?"
   },
-  "upload-british-passport" : {
+  "upload-british-passport": {
     "header": "Upload British passport",
     "label": "Upload a file",
-    "hint": "Your file must be JPG, JPEG, PDF or PNG and be 25MB or less",
-    "paragraph1": "Attach an image of your British passport as proof of your identity. The image must be",
+    "hint": "Your file must be JPEG, PDF or PNG and be 25MB or less",
+    "paragraph1": "Attach an image of your British passport as proof of your identity. the image must be",
     "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
     "link-text" : "signed by your countersignatory (opens in a new tab).",
     "uploading-document": "Document uploading",
-    "not-uploaded": "No file uploaded", 
-    "uploaded": "Files uploaded" 
+    "not-uploaded": "No files uploaded", 
+    "uploaded": "File uploaded" 
   },
-  "upload-passport" : {
+  "upload-passport": {
     "header": "Upload passport",
     "label": "Upload a file",
     "hint": "Your file must be JPG, JPEG, PDF or PNG and be 25MB or less",
@@ -47,8 +47,19 @@
     "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
     "link-text" : "signed by your countersignatory (opens in a new tab).",
     "uploading-document": "Document uploading",
-    "not-uploaded": "No file uploaded", 
-    "uploaded": "Files uploaded" 
+    "not-uploaded": "No files uploaded", 
+    "uploaded": "File uploaded" 
+  },
+  "upload-driving-licence": {
+    "header": "Upload UK driving licence",
+    "label": "Upload a file",
+    "hint": "Your file must be JPG, JPEG, PDF or PNG and be 25MB or less",
+    "paragraph1": "Attach an image of your driving licence photocard as proof of your identity. The image must be",
+    "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
+    "link-text" : "signed by your countersignatory (opens in a new tab).",
+    "uploading-document": "Document uploading",
+    "not-uploaded": "No files uploaded", 
+    "uploaded": "File uploaded" 
   },
   "select-precursor": {
     "header": "Explosives precursors",
@@ -152,13 +163,16 @@
         "label": "Passport number"
       },
       "amend-Uk-driving-licence-number": {
-        "label": "Driving Licence"
+        "label": "UK driving licence number"
       },
       "amend-british-passport" : {
         "label": "British passport attachment"
       },
       "amend-eu-passport" : {
         "label": "Passport attachment"
+      },
+      "amend-uk-driving-licence" : {
+        "label": "UK driving licence attachment"
       },
       "amend-new-country": {
         "label": "Country"

--- a/apps/epp-amend/translations/src/en/validation.json
+++ b/apps/epp-amend/translations/src/en/validation.json
@@ -94,7 +94,8 @@
         "maxFileSize": "The selected file must 25MB or smaller",
         "fileType": "The selected file must be a JPG, JPEG, PDF or PNG",
         "maxAmendBritishPassport": "You can only upload up to {{maxAmendBritishPassport}} files or less. Remove a file before uploading another",
-        "maxAmendPassport": "You can only upload up to {{maxAmendPassport}} files or less. Remove a file before uploading another"
+        "maxAmendPassport": "You can only upload up to {{maxAmendPassport}} files or less. Remove a file before uploading another",
+        "maxAmendDrivingLicence": "You can only upload up to {{maxAmendDrivingLicence}} files or less. Remove a file before uploading another"
       },
     "amend-new-name-title": {
         "required" : "Select the title of your new name"

--- a/apps/epp-amend/views/upload-driving-licence.html
+++ b/apps/epp-amend/views/upload-driving-licence.html
@@ -1,0 +1,47 @@
+{{<partials-page}}
+{{$encoding}}enctype="multipart/form-data" name="file-upload-form" {{/encoding}}
+{{$page-content}}
+<p>{{#t}}pages.upload-driving-licence.paragraph1{{/t}}
+   <a class="govuk-link" href="{{#t}}pages.upload-driving-licence.link{{/t}}" rel="noreferrer noopener" target="_blank">{{#t}}pages.upload-driving-licence.link-text{{/t}}</a>
+</p>
+<div class="govuk-form-group" id="hofFileUpload">
+   <label class="govuk-label" for="file-upload">
+      <h2>{{#t}}pages.upload-driving-licence.label{{/t}}</h2>
+      <span class="govuk-hint">{{#t}}pages.upload-driving-licence.hint{{/t}}</span>
+   </label>
+   <p id="file-upload-error-maxFileSize" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.maxFileSize{{/t}}
+   </p>
+   <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
+   </p>
+   <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="amend-uk-driving-licence">
+   <div id="upload-page-loading-spinner" class="spinner-container">
+      <div class="spinner-loader"></div>
+      <span class="spinner-message">{{#t}}pages.upload-driving-licence.uploading-document{{/t}}</span>
+   </div>
+</div>
+{{^values.amend-uk-driving-licence}}
+<h2 class="govuk-heading-m">{{#t}}pages.upload-driving-licence.not-uploaded{{/t}}</h2>
+{{/values.amend-uk-driving-licence}}
+{{#values.amend-uk-driving-licence.length}}
+<h2 class="govuk-heading-m">{{#t}}pages.upload-driving-licence.uploaded{{/t}}</h2>
+<div id="uploaded-documents" class="govuk-width-container">
+   {{#values.amend-uk-driving-licence}}
+   <div class="govuk-grid-row">
+       <div class="govuk-grid-column-three-quarters">
+           {{name}}
+       </div>
+       <div class="govuk-grid-column-one-quarter">
+           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+       </div>
+   </div>
+   <div class="file-upload-hrline"></div>
+   {{/values.amend-uk-driving-licence}}
+</div>
+{{/values.amend-uk-driving-licence.length}}
+<button class="govuk-button" name="requireFileUpload" value="amend-uk-driving-licence">
+   {{#t}}buttons.continue{{/t}}
+</button>
+{{/page-content}}
+{{/partials-page}}

--- a/config.js
+++ b/config.js
@@ -76,6 +76,11 @@ module.exports = {
         limit: 1,
         limitValidationError: 'maxAmendPassport'
       },
+      'amend-uk-driving-licence': {
+        allowMultipleUploads: false,
+        limit: 1,
+        limitValidationError: 'maxAmendDrivingLicence'
+      },
       'new-renew-proof-address': {
         allowMultipleUploads: true,
         limit: 2,


### PR DESCRIPTION
## What? 
add upload (EU) passport page as per jira ticket [EPP-104](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-104)
## Why? 
to allow user to upload other type of identification document such driving licence
## How? 
configured the following files as follows: 
- add create html for upload passport
- add content in pages.json
- add section in summary-data-section
- update index.js with the new page
- add in validation.json and config.js max limit error message in case limit increase more than 1.


## Testing?
manual test on local
## Screenshots (optional)
## Anything Else? (optional)
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
