### PR TITLE
EPP-119 amend UPLOAD PROOF OF ADDRESS

### DIFF
--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -161,11 +161,11 @@ module.exports = {
       locals: { captionHeading: 'Section 11 of 20' }
     },
     '/upload-proof-address': {
-      next: '/section-twelve'
-    },
-    '/section-twelve': {
-      fields: ['amend-reason-for-licence'],
-      next: '/change-substances'
+      behaviours: [SaveDocument('amend-proof-address', 'file-upload'), RemoveDocument('amend-proof-address')],
+      fields: ['file-upload'],
+      continueOnEdit: true,
+      next: '/change-substances',
+      locals: { captionHeading: 'Section 12 of 23' }
     },
     '/change-substances': {
       fields: ['amend-explosive-precusor-type'],

--- a/apps/epp-amend/sections/summary-data-sections.js
+++ b/apps/epp-amend/sections/summary-data-sections.js
@@ -187,6 +187,22 @@ module.exports = {
         step: '/new-address',
         field: 'amend-new-date-moved-to-address',
         parse: date => date && dateFormatter.format(new Date(date))
+      },
+      {
+        step: '/upload-proof-address',
+        field: 'amend-proof-address',
+        parse: (documents, req) => {
+          if (
+            req.sessionModel
+              .get('steps')
+              .includes('/upload-proof-address') &&
+            documents?.length > 0
+          ) {
+            return documents.map(file => file?.name)?.join('\n\n');
+          }
+
+          return null;
+        }
       }
     ]
   },

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -32,12 +32,33 @@
     "header": "Upload British passport",
     "label": "Upload a file",
     "hint": "Your file must be JPEG, PDF or PNG and be 25MB or less",
-    "paragraph1": "Attach an image of your British passport as proof of your identity. the image must be",
+    "paragraph1": "Attach an image of your British passport as proof of your identity. The image must be",
     "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
-    "link-text" : "signed by your countersignatory (opens in a new tab).",
+    "link-text": "signed by your countersignatory (opens in a new tab).",
     "uploading-document": "Document uploading",
-    "not-uploaded": "No files uploaded", 
-    "uploaded": "File uploaded" 
+    "not-uploaded": "No file uploaded", 
+    "uploaded": "Files uploaded" 
+  },
+
+  "upload-proof-address" : {
+    "header": "Upload proof of address",
+    "paragraph1": "You need to scan and attach 2 documents as proof of your home address. The documents must be dated within the last 3 months and",
+    "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
+    "link-text": "signed by your countersignatory (opens in a new tab).",
+    "paragraph2": "The first document must be one of the following:",
+    "paragraph2-li1": "mortgage statement",
+    "paragraph2-li2": "bank or building society statement",
+    "paragraph3": "The second document must be one of the following:",
+    "paragraph3-li1": "credit card statement",
+    "paragraph3-li2": "rental agreement",
+    "paragraph3-li3": "utilities bill (including energy, water, internet or phone bills)",
+    "paragraph3-li4": "council tax bill",
+    "paragraph3-li5": "benefit statement",
+    "label": "Upload a file",
+    "hint": "Your file must be JPEG, PDF or PNG and be 25MB or less",
+    "uploading-document": "Document uploading",
+    "not-uploaded": "No file uploaded", 
+    "uploaded": "Files uploaded" 
   },
   "select-precursor": {
     "header": "Explosives precursors",

--- a/apps/epp-amend/translations/src/en/validation.json
+++ b/apps/epp-amend/translations/src/en/validation.json
@@ -93,7 +93,8 @@
         "required": "Select a file to upload",
         "maxFileSize": "The selected file must 25MB or smaller",
         "fileType": "The selected file must be a JPG, PDF or PNG",
-        "maxAmendBritishPassport": "You can only upload up to {{maxAmendBritishPassport}} files or less. Remove a file before uploading another "
+        "maxAmendBritishPassport": "You can only upload up to {{maxAmendBritishPassport}} files or less. Remove a file before uploading another",
+        "maxAmendProofAddress": "You can only upload up to {{maxAmendProofAddress}} files or less. Remove a file before uploading another"
       },
     "amend-new-name-title": {
         "required" : "Select the title of your new name"

--- a/apps/epp-amend/views/upload-british-passport.html
+++ b/apps/epp-amend/views/upload-british-passport.html
@@ -25,7 +25,6 @@
 <h2 class="govuk-heading-m">{{#t}}pages.upload-british-passport.not-uploaded{{/t}}</h2>
 {{/values.amend-british-passport}}
 {{#values.amend-british-passport.length}}
-<br>
 <h2 class="govuk-heading-m">{{#t}}pages.upload-british-passport.uploaded{{/t}}</h2>
 <div id="uploaded-documents" class="govuk-width-container">
    {{#values.amend-british-passport}}

--- a/apps/epp-amend/views/upload-proof-address.html
+++ b/apps/epp-amend/views/upload-proof-address.html
@@ -1,0 +1,75 @@
+{{<partials-page}} {{$encoding}}enctype="multipart/form-data" name="file-upload-form" {{/encoding}}
+{{$page-content}}
+<p class="govuk-body">{{#t}}pages.upload-proof-address.paragraph1{{/t}}
+    <a class="govuk-link" href="{{#t}}pages.upload-proof-address.link{{/t}}" target="_blank" rel="noreferrer noopener">
+        {{#t}}pages.upload-proof-address.link-text{{/t}}
+    </a>
+</p>
+
+<p class="govuk-body">{{#t}}pages.upload-proof-address.paragraph2{{/t}}</p>
+
+<ul class="govuk-!-margin-top-2 govuk-!-margin-left-2">
+    <li>{{#t}}pages.upload-proof-address.paragraph2-li1{{/t}}</li>
+    <li>{{#t}}pages.upload-proof-address.paragraph2-li2{{/t}}</li>
+  </ul>
+
+<p class="govuk-body">{{#t}}pages.upload-proof-address.paragraph3{{/t}}</p>
+
+<ul class="govuk-!-margin-top-2 govuk-!-margin-left-2">
+    <li>{{#t}}pages.upload-proof-address.paragraph3-li1{{/t}}</li>
+    <li>{{#t}}pages.upload-proof-address.paragraph3-li2{{/t}}</li>
+    <li>{{#t}}pages.upload-proof-address.paragraph3-li3{{/t}}</li>
+    <li>{{#t}}pages.upload-proof-address.paragraph3-li4{{/t}}</li>
+    <li>{{#t}}pages.upload-proof-address.paragraph3-li5{{/t}}</li>
+</ul>
+
+<div class="govuk-form-group" id="hofFileUpload">
+    <label class="govuk-label" for="file-upload">
+        <h2>{{#t}}pages.upload-proof-address.label{{/t}}</h2>
+        <span class="govuk-hint">{{#t}}pages.upload-proof-address.hint{{/t}}</span>
+    </label>
+    <p id="file-upload-error-maxFileSize" class="govuk-error-message govuk-!-display-none">
+        <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.maxFileSize{{/t}}
+    </p>
+    <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
+        <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
+    </p>
+    <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="amend-proof-address">
+
+    <div id="upload-page-loading-spinner" class="spinner-container">
+        <div class="spinner-loader"></div>
+        <span class="spinner-message">{{#t}}pages.upload-proof-address.uploading-document{{/t}}</span>
+    </div>
+
+</div>
+
+{{^values.amend-proof-address}}
+<h2 class="govuk-heading-m">{{#t}}pages.upload-proof-address.not-uploaded{{/t}}</h2>
+{{/values.amend-proof-address}}
+
+{{#values.amend-proof-address.length}}
+<h2 class="govuk-heading-m">{{#t}}pages.upload-proof-address.uploaded{{/t}}</h2>
+
+<div id="uploaded-documents" class="govuk-width-container">
+    {{#values.amend-proof-address}}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+            {{name}}
+        </div>
+        <div class="govuk-grid-column-one-quarter">
+            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+        </div>
+    </div>
+    <div class="file-upload-hrline"></div>
+    {{/values.amend-proof-address}}
+</div>
+
+{{/values.amend-proof-address.length}}
+
+
+<button class="govuk-button" name="requireFileUpload" value="amend-proof-address">
+    {{#t}}buttons.continue{{/t}}
+</button>
+
+{{/page-content}}
+{{/partials-page}}

--- a/config.js
+++ b/config.js
@@ -75,6 +75,11 @@ module.exports = {
         allowMultipleUploads: true,
         limit: 2,
         limitValidationError: 'maxNewRenewProofAddress'
+      },
+      'amend-proof-address': {
+        allowMultipleUploads: true,
+        limit: 2,
+        limitValidationError: 'maxAmendProofAddress'
       }
     }
   },


### PR DESCRIPTION
## What? 
add upload proof of address page as per jira ticket [EPP-119](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-119)
## Why? 
to allow user to upload documents that prove their residency
## How? 
configured the following files as follows:
- add create html for upload passport
- add content in pages.json
- add section in summary-data-section
- update index.js with the new page
- add in validation.json and config.js max limit error message in case limit increase more than 2.
## Testing?
manual test
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
