### PR TITLE
EPP-105 amend create upload certificate of good conduct

### DIFF
--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -131,6 +131,9 @@ module.exports = {
       locals: { captionHeading: 'Section 9 of 23' }
     },
     '/upload-certificate-conduct': {
+      behaviours: [SaveDocument('amend-certificate-conduct', 'file-upload'),
+        RemoveDocument('amend-certificate-conduct')],
+      fields: ['file-upload'],
       next: '/change-home-address',
       locals: { captionHeading: 'Section 9 of 23' }
     },

--- a/apps/epp-amend/sections/summary-data-sections.js
+++ b/apps/epp-amend/sections/summary-data-sections.js
@@ -163,6 +163,22 @@ module.exports = {
         }
       },
       {
+        step: '/upload-certificate-conduct',
+        field: 'amend-certificate-conduct',
+        parse: (documents, req) => {
+          if (
+            req.sessionModel
+              .get('steps')
+              .includes('/upload-certificate-conduct') &&
+            documents?.length > 0
+          ) {
+            return documents.map(file => file.name);
+          }
+
+          return null;
+        }
+      },
+      {
         step: '/upload-driving-licence',
         field: 'amend-uk-driving-licence',
         parse: (documents, req) => {

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -50,6 +50,18 @@
     "not-uploaded": "No files uploaded", 
     "uploaded": "File uploaded" 
   },
+  "upload-certificate-conduct": {
+    "header": "Upload certificate of good conduct (optional)",
+    "label": "Upload a file",
+    "hint": "Your file must be JPG, JPEG, PDF or PNG and be 25MB or less",
+    "paragraph1": "A certificate of good conduct is issued by the police in your country of nationality. It shows if you have a criminal record and details of any offences.",
+    "paragraph2": "Attach an image of your certificate of good conduct. The image must be ",
+    "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
+    "link-text" : "signed by your countersignatory (opens in a new tab).",
+    "uploading-document": "Document uploading",
+    "not-uploaded": "No files uploaded", 
+    "uploaded": "File uploaded" 
+  },
   "upload-driving-licence": {
     "header": "Upload UK driving licence",
     "label": "Upload a file",
@@ -170,6 +182,9 @@
       },
       "amend-eu-passport" : {
         "label": "Passport attachment"
+      },
+      "amend-certificate-conduct" :{
+         "label": "Certificate of good conduct attachment"
       },
       "amend-uk-driving-licence" : {
         "label": "UK driving licence attachment"

--- a/apps/epp-amend/translations/src/en/validation.json
+++ b/apps/epp-amend/translations/src/en/validation.json
@@ -95,7 +95,8 @@
         "fileType": "The selected file must be a JPG, JPEG, PDF or PNG",
         "maxAmendBritishPassport": "You can only upload up to {{maxAmendBritishPassport}} files or less. Remove a file before uploading another",
         "maxAmendPassport": "You can only upload up to {{maxAmendPassport}} files or less. Remove a file before uploading another",
-        "maxAmendDrivingLicence": "You can only upload up to {{maxAmendDrivingLicence}} files or less. Remove a file before uploading another"
+        "maxAmendDrivingLicence": "You can only upload up to {{maxAmendDrivingLicence}} files or less. Remove a file before uploading another",
+        "maxAmendCertificateConduct": "You can only upload up to {{maxAmendCertificateConduct}} files or less. Remove a file before uploading another"
       },
     "amend-new-name-title": {
         "required" : "Select the title of your new name"

--- a/apps/epp-amend/views/upload-certificate-conduct.html
+++ b/apps/epp-amend/views/upload-certificate-conduct.html
@@ -1,0 +1,48 @@
+{{<partials-page}}
+{{$encoding}}enctype="multipart/form-data" name="file-upload-form" {{/encoding}}
+{{$page-content}}
+<p>{{#t}}pages.upload-certificate-conduct.paragraph1{{/t}}</p>
+   <p>{{#t}}pages.upload-certificate-conduct.paragraph2{{/t}}
+   <a class="govuk-link" href="{{#t}}pages.upload-certificate-conduct.link{{/t}}" rel="noreferrer noopener" target="_blank">{{#t}}pages.upload-certificate-conduct.link-text{{/t}}</a>
+</p>
+<div class="govuk-form-group" id="hofFileUpload">
+   <label class="govuk-label" for="file-upload">
+      <h2>{{#t}}pages.upload-certificate-conduct.label{{/t}}</h2>
+      <span class="govuk-hint">{{#t}}pages.upload-certificate-conduct.hint{{/t}}</span>
+   </label>
+   <p id="file-upload-error-maxFileSize" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.maxFileSize{{/t}}
+   </p>
+   <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
+   </p>
+   <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="amend-certificate-conduct">
+   <div id="upload-page-loading-spinner" class="spinner-container">
+      <div class="spinner-loader"></div>
+      <span class="spinner-message">{{#t}}pages.upload-certificate-conduct.uploading-document{{/t}}</span>
+   </div>
+</div>
+{{^values.amend-certificate-conduct}}
+<h2 class="govuk-heading-m">{{#t}}pages.upload-certificate-conduct.not-uploaded{{/t}}</h2>
+{{/values.amend-certificate-conduct}}
+{{#values.amend-certificate-conduct.length}}
+<h2 class="govuk-heading-m">{{#t}}pages.upload-certificate-conduct.uploaded{{/t}}</h2>
+<div id="uploaded-documents" class="govuk-width-container">
+   {{#values.amend-certificate-conduct}}
+   <div class="govuk-grid-row">
+       <div class="govuk-grid-column-three-quarters">
+           {{name}}
+       </div>
+       <div class="govuk-grid-column-one-quarter">
+           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+       </div>
+   </div>
+   <div class="file-upload-hrline"></div>
+   {{/values.amend-certificate-conduct}}
+</div>
+{{/values.amend-certificate-conduct.length}}
+<button class="govuk-button" name="optionalFileUpload" value="amend-certificate-conduct">
+   {{#t}}buttons.continue{{/t}}
+</button>
+{{/page-content}}
+{{/partials-page}}

--- a/config.js
+++ b/config.js
@@ -76,6 +76,11 @@ module.exports = {
         limit: 1,
         limitValidationError: 'maxAmendPassport'
       },
+      'amend-certificate-conduct': {
+        allowMultipleUploads: false,
+        limit: 1,
+        limitValidationError: 'maxAmendCertificateConduct'
+      },
       'amend-uk-driving-licence': {
         allowMultipleUploads: false,
         limit: 1,


### PR DESCRIPTION
## What? 
As per Jira ticket [EPP-105](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-105) created "upload certificate of good conduct"  in the amend user journey.
## Why? 
to allow user to update documents to prove the good conduct. 
## How? 
- add new field in index.js, pages.json and summay-data-section.js
- add upload-certificate-conduct.html file
- update validation.json and config.file to handle file upload limits
## Testing?
manual test
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
