### PR TITLE
EPP-146 amend CHANGE SUBSTANCES page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 ### Explosives precursors and poisons
 ## TBD
+

--- a/apps/epp-amend/fields/index.js
+++ b/apps/epp-amend/fields/index.js
@@ -305,20 +305,6 @@ module.exports = {
     options: ['yes', 'no'],
     validate: 'required'
   },
-  'amend-new-date-moved-to-address': dateComponent('amend-new-date-moved-to-address', {
-    mixin: 'input-date',
-    legend: { className: 'bold' },
-    validate: ['required', 'date', 'before']
-  }),
-  'amend-change-substances-options': {
-    mixin: 'radio-group',
-    legend: {
-      className: 'govuk-label--m'
-    },
-    className: ['govuk-radios', 'govuk-radios--inline'],
-    options: ['yes', 'no'],
-    validate: 'required'
-  },
   'amend-precursor-field': {
     mixin: 'select',
     validate: ['required'],

--- a/apps/epp-amend/fields/index.js
+++ b/apps/epp-amend/fields/index.js
@@ -4,7 +4,6 @@ const precursorList = require('../../../utilities/constants/explosive-precursors
 const poisonsList = require('../../../utilities/constants/poisons.js');
 const helpers = require('../../../utilities/helpers/index.js');
 const country = require('../../../utilities/constants/countries');
-
 const countersignatoryYears = require('../../../utilities/constants/countersignatory-years.js');
 
 module.exports = {
@@ -297,6 +296,29 @@ module.exports = {
       validate: ['required', 'date', 'before']
     }
   ),
+  'amend-change-substances-options': {
+    mixin: 'radio-group',
+    legend: {
+      className: 'govuk-label--m'
+    },
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    options: ['yes', 'no'],
+    validate: 'required'
+  },
+  'amend-new-date-moved-to-address': dateComponent('amend-new-date-moved-to-address', {
+    mixin: 'input-date',
+    legend: { className: 'bold' },
+    validate: ['required', 'date', 'before']
+  }),
+  'amend-change-substances-options': {
+    mixin: 'radio-group',
+    legend: {
+      className: 'govuk-label--m'
+    },
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    options: ['yes', 'no'],
+    validate: 'required'
+  },
   'amend-precursor-field': {
     mixin: 'select',
     validate: ['required'],

--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -97,17 +97,10 @@ module.exports = {
             field: 'amend-name-options',
             value: 'yes'
           }
-        },
-        {
-          target: '/change-home-address',
-          condition: {
-            field: 'amend-name-options',
-            value: 'no'
-          }
         }
       ],
       locals: { captionHeading: 'Section 6 of 23' },
-      next: '/new-name'
+      next: '/change-home-address'
     },
     '/new-name': {
       fields: [
@@ -199,17 +192,10 @@ module.exports = {
             field: 'amend-home-address-options',
             value: 'yes'
           }
-        },
-        {
-          target: '/change-substances',
-          condition: {
-            field: 'amend-home-address-options',
-            value: 'no'
-          }
         }
       ],
       locals: { captionHeading: 'Section 10 of 23' },
-      next: '/new-address'
+      next: '/change-substances'
     },
     '/new-address': {
       fields: [
@@ -243,10 +229,18 @@ module.exports = {
         )
       ],
       fields: ['amend-change-substances-options'],
-      continueOnEdit: true,
-      next: '/explosives-precursors',
+      forks: [
+        {
+          target: '/explosives-precursors',
+          continueOnEdit: true,
+          condition: {
+            field: 'amend-change-substances-options',
+            value: 'yes'
+          }
+        }
+      ],
+      next: '/countersignatory-details',
       locals: { captionHeading: 'Section 13 of 23' }
-
     },
     '/no-details-amend': {
       locals: { captionHeading: 'Section 13 of 23' }

--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -84,7 +84,10 @@ module.exports = {
           'amend-eu-passport',
           'amend-certificate-conduct',
           'amend-uk-driving-licence'
-        ])
+        ]),
+        CheckAndRedirect('amend-name-options',
+          ['amend-change-substances-options', 'amend-name-options', 'amend-home-address-options']
+        )
       ],
       fields: ['amend-name-options'],
       forks: [
@@ -183,7 +186,10 @@ module.exports = {
       behaviours: [
         DeleteRedundantDocuments('amend-home-address-options', [
           'amend-proof-address'
-        ])
+        ]),
+        CheckAndRedirect('amend-home-address-options',
+          ['amend-change-substances-options', 'amend-name-options', 'amend-home-address-options']
+        )
       ],
       fields: ['amend-home-address-options'],
       forks: [

--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -9,9 +9,9 @@ const RemoveDocument = require('../epp-common/behaviours/remove-document');
 const DobEditRedirect = require('../epp-common/behaviours/dob-edit-redirect');
 const RenderPrecursorDetails = require('../epp-common/behaviours/render-precursors-detail');
 const SaveHomeAddress = require('../epp-common/behaviours/save-home-address');
+const CheckAndRedirect = require('../epp-common/behaviours/check-answer-redirect');
 const UploadFileCounter = require('../epp-common/behaviours/uploaded-files-counter');
 const DobUnder18Redirect = require('../epp-common/behaviours/dob-under18-redirect');
-
 const DeleteRedundantDocuments = require('../epp-common/behaviours/delete-redundant-documents');
 
 module.exports = {
@@ -70,7 +70,10 @@ module.exports = {
       locals: { captionHeading: 'Section 4 of 23' }
     },
     '/contact-details': {
-      fields: ['amend-phone-number', 'amend-email'],
+      fields: [
+        'amend-phone-number',
+        'amend-email'
+      ],
       locals: { captionHeading: 'Section 5 of 23' },
       next: '/amend-details'
     },
@@ -228,9 +231,19 @@ module.exports = {
       locals: { captionHeading: 'Section 12 of 23' }
     },
     '/change-substances': {
-      fields: ['amend-explosive-precusor-type'],
-      locals: { captionHeading: 'Section 13 of 23' },
-      next: '/explosives-precursors'
+      behaviours: [
+        CheckAndRedirect('amend-change-substances-options',
+          ['amend-change-substances-options', 'amend-name-options', 'amend-home-address-options']
+        )
+      ],
+      fields: ['amend-change-substances-options'],
+      continueOnEdit: true,
+      next: '/explosives-precursors',
+      locals: { captionHeading: 'Section 13 of 23' }
+
+    },
+    '/no-details-amend': {
+      locals: { captionHeading: 'Section 13 of 23' }
     },
     '/explosives-precursors': {
       fields: ['amend-regulated-explosives-precursors'],

--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -334,7 +334,7 @@ module.exports = {
         'amend-countersignatory-Uk-driving-licence-number'
       ],
       locals: { captionHeading: 'Section 21 of 23' },
-      next: '/birth-certificate'
+      next: '/confirm'
     },
     '/birth-certificate': {
       behaviours: [

--- a/apps/epp-amend/sections/summary-data-sections.js
+++ b/apps/epp-amend/sections/summary-data-sections.js
@@ -256,18 +256,10 @@ module.exports = {
       }
     ]
   },
-  'amend-licence-for-explosives-precursors': {
-    steps: [
-      {
-        steps: '/explosives-precursors',
-        field: 'amend-regulated-explosives-precursors'
-      }
-    ]
-  },
   'amend-change-substances': {
     steps: [
       {
-        step: '/change-home-address',
+        step: '/change-substances',
         field: 'amend-change-substances-options'
       }
     ]
@@ -277,6 +269,14 @@ module.exports = {
       {
         steps: '/select-precursor',
         field: 'amend-precursor-field'
+      }
+    ]
+  },
+  'amend-licence-for-explosives-precursors': {
+    steps: [
+      {
+        steps: '/explosives-precursors',
+        field: 'amend-regulated-explosives-precursors'
       }
     ]
   },

--- a/apps/epp-amend/sections/summary-data-sections.js
+++ b/apps/epp-amend/sections/summary-data-sections.js
@@ -264,6 +264,14 @@ module.exports = {
       }
     ]
   },
+  'amend-change-substances': {
+    steps: [
+      {
+        step: '/change-home-address',
+        field: 'amend-change-substances-options'
+      }
+    ]
+  },
   'amend-explosives-precursor': {
     steps: [
       {

--- a/apps/epp-amend/translations/src/en/fields.json
+++ b/apps/epp-amend/translations/src/en/fields.json
@@ -148,6 +148,17 @@
       "legend": "What date did you change your address?",
       "hint": " For example, 30 09 1969"
   },
+  "amend-change-substances-options":{
+    "legend": "Do you need to amend the substances on your licence?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
   "amend-precursor-field": {
     "hint": "Select an explosives precursor",
     "options":{

--- a/apps/epp-amend/translations/src/en/fields.json
+++ b/apps/epp-amend/translations/src/en/fields.json
@@ -110,7 +110,6 @@
     "label": "What is your driving licence number?",
     "hint" : "On section 5 of your licence, for example MORGA657054SM9IJ"    
   },
- 
   "amend-home-address-options": {
     "legend": "Do you need to amend your home address on the licence?",
     "options": {

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -187,11 +187,11 @@
       "amend-new-home-address": {
         "header": "New address"
       },
-      "amend-licence-for-explosives-precursors": {
-        "header": "Licence for explosives precursors"
-      },
       "amend-change-substances": {
         "header": "Amend substances"
+      },
+      "amend-licence-for-explosives-precursors": {
+        "header": "Licence for explosives precursors"
       },
       "amend-explosives-precursor": {
         "header": "Explosives precursors"
@@ -279,8 +279,8 @@
       "amend-new-country": {
         "label": "Country"
       },
-      "amend-home-address-options": {
-        "label": "Do you need to amend the substances on your licence?"
+      "amend-proof-address":{
+         "label": "Proof of address attachment"
       },
       "amend-precursor-field": {
         "label": "Explosives precursor"

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -96,6 +96,13 @@
     "not-uploaded": "No files uploaded", 
     "uploaded": "File uploaded" 
   },
+  "change-substances": {
+    "header": "Change in substances",
+    "paragraph1": "You must amend the substances on your licence if you:",
+    "li1": "need to add or remove substances you can acquire, possess or use",
+    "li2": "need to change the concentration or volume of substances that your licence covers",
+    "li3": "have changed your storage or usage address since your current licence was issued"
+  },
   "select-precursor": {
     "header": "Explosives precursors",
     "p1": "Tell us which explosives precursors you want to import acquire use or possess.",
@@ -183,6 +190,9 @@
       "amend-licence-for-explosives-precursors": {
         "header": "Licence for explosives precursors"
       },
+      "amend-change-substances": {
+        "header": "Amend substances"
+      },
       "amend-explosives-precursor": {
         "header": "Explosives precursors"
       },
@@ -269,8 +279,8 @@
       "amend-new-country": {
         "label": "Country"
       },
-      "amend-proof-address":{
-         "label": "Proof of address attachment"
+      "amend-home-address-options": {
+        "label": "Do you need to amend the substances on your licence?"
       },
       "amend-precursor-field": {
         "label": "Explosives precursor"

--- a/apps/epp-amend/translations/src/en/validation.json
+++ b/apps/epp-amend/translations/src/en/validation.json
@@ -162,6 +162,9 @@
         "before": "Date you moved to this address must be in the past",
         "after": "Date you moved to this address must be after {{diff}}, your date of birth"
     },
+    "amend-change-substances-options": {
+      "required" : "Select if you need to amend the substances on your licence"
+    },
     "amend-precursor-field": {
       "required" : "Select an explosive precursor"
     },

--- a/apps/epp-amend/views/change-substances.html
+++ b/apps/epp-amend/views/change-substances.html
@@ -1,0 +1,17 @@
+{{<partials-page}}
+  {{$page-content}}
+<div>
+    <p class="govuk-body">{{#t}}pages.change-substances.paragraph1{{/t}}</p>
+    <ul class="govuk-list govuk-list--bullet"> 
+        <li>{{#t}}pages.change-substances.li1{{/t}}</li>
+        <li>{{#t}}pages.change-substances.li2{{/t}}</li>
+        <li>{{#t}}pages.change-substances.li3{{/t}}</li>
+    </ul>
+</div>
+  
+  {{#fields}}
+    {{#renderField}}amend-change-substances-options{{/renderField}}
+  {{/fields}}
+  {{#input-submit}}continue{{/input-submit}} 
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/epp-common/behaviours/check-answer-redirect.js
+++ b/apps/epp-common/behaviours/check-answer-redirect.js
@@ -1,0 +1,12 @@
+module.exports = (currentField, fieldsArray) => superclass =>
+  class extends superclass {
+    successHandler(req, res, next) {
+      const threeNo = fieldsArray.every(fieldsArrayValue => req.sessionModel.get(fieldsArrayValue) === 'no');
+      if (threeNo) {
+        return res.redirect(`${req.baseUrl}/no-details-amend`);
+      } else if (req.body[currentField] === 'no' && !threeNo && currentField === 'amend-change-substances-options') {
+        return res.redirect(`${req.baseUrl}/countersignatory-details`);
+      }
+      return super.successHandler(req, res, next);
+    }
+  };

--- a/apps/epp-common/behaviours/check-answer-redirect.js
+++ b/apps/epp-common/behaviours/check-answer-redirect.js
@@ -4,9 +4,6 @@ module.exports = (currentField, fieldsArray) => superclass =>
       const allFieldsNo = fieldsArray.every(fieldsArrayValue => req.sessionModel.get(fieldsArrayValue) === 'no');
       if (allFieldsNo) {
         return res.redirect(`${req.baseUrl}/no-details-amend`);
-      } else if (req.form.values[currentField] === 'no' && !allFieldsNo
-        && currentField === 'amend-change-substances-options') {
-        return res.redirect(`${req.baseUrl}/countersignatory-details`);
       }
       return super.successHandler(req, res, next);
     }

--- a/apps/epp-common/behaviours/check-answer-redirect.js
+++ b/apps/epp-common/behaviours/check-answer-redirect.js
@@ -1,10 +1,11 @@
 module.exports = (currentField, fieldsArray) => superclass =>
   class extends superclass {
     successHandler(req, res, next) {
-      const threeNo = fieldsArray.every(fieldsArrayValue => req.sessionModel.get(fieldsArrayValue) === 'no');
-      if (threeNo) {
+      const allFieldsNo = fieldsArray.every(fieldsArrayValue => req.sessionModel.get(fieldsArrayValue) === 'no');
+      if (allFieldsNo) {
         return res.redirect(`${req.baseUrl}/no-details-amend`);
-      } else if (req.body[currentField] === 'no' && !threeNo && currentField === 'amend-change-substances-options') {
+      } else if (req.form.values[currentField] === 'no' && !allFieldsNo
+        && currentField === 'amend-change-substances-options') {
         return res.redirect(`${req.baseUrl}/countersignatory-details`);
       }
       return super.successHandler(req, res, next);

--- a/test/unit/behaviours/check-answer-redirect.spec.js
+++ b/test/unit/behaviours/check-answer-redirect.spec.js
@@ -47,7 +47,7 @@ describe('Tests for check-answer-redirect behaviour', () => {
       expect(req.sessionModel.set.calledWith('test-field-name', 'no'));
     });
 
-    it('current fields answer is - no - should redirect to the given redirect /countersignatory-details - ', () => {
+    it('current fields answer is - no - should redirect to the fork redirect URL - ', () => {
       req = {
         sessionModel: {
           set: sinon.spy(),
@@ -61,17 +61,13 @@ describe('Tests for check-answer-redirect behaviour', () => {
         currentField: 'amend-change-substances-options',
         form: {
           values: {
-            'amend-change-substances-options': 'no'
+            'test-field-name': 'no'
           }
         }
       };
-      instance = new (Behaviour('amend-change-substances-options', [
-        'test-field-name',
-        'test-field-name-two',
-        'test-field-name-three'])(Base))();
       instance.successHandler(req, res, next);
-      expect(res.redirect.calledOnce).to.be.true;
-      expect(res.redirect.calledWith(`${req.baseUrl}/countersignatory-details`)).to.be.true;
+      expect(res.redirect.calledOnce).to.be.false;
+      sinon.assert.calledWithExactly(Base.prototype.successHandler, req, res, next);
       expect(req.sessionModel.set.calledWith('test-field-name', 'no'));
     });
 

--- a/test/unit/behaviours/check-answer-redirect.spec.js
+++ b/test/unit/behaviours/check-answer-redirect.spec.js
@@ -1,0 +1,101 @@
+const Behaviour = require('../../../apps/epp-common/behaviours/check-answer-redirect');
+
+describe('Tests for check-answer-redirect behaviour', () => {
+  class Base {
+    constructor() {}
+    successHandler() {}
+  }
+
+  let req;
+  let res;
+  let instance;
+  const next = sinon.spy();
+
+  beforeEach(() => {
+    req = reqres.req();
+    res = reqres.res();
+  });
+  describe('successHandler tests', () => {
+    beforeEach(() => {
+      sinon.stub(Base.prototype, 'successHandler').returns(req, res, next);
+      instance = new (Behaviour('test-field-name', [
+        'test-field-name',
+        'test-field-name-two',
+        'test-field-name-three'])(Base))();
+    });
+
+    it('init - successHandler', () => {
+      instance.successHandler(req, res, next);
+      expect(Base.prototype.successHandler).to.have.been.called;
+    });
+
+    it('All fields answer is - no - should redirect to the given redirect /no-details-amend - ', () => {
+      req = {
+        sessionModel: {
+          set: sinon.spy(),
+          get: fieldName => req.sessionModel[fieldName],
+          'test-field-name-three': 'no',
+          'test-field-name-two': 'no',
+          'test-field-name': 'no'
+        },
+        originalUrl: 'http://domain/path',
+        baseUrl: '/amend'
+      };
+      instance.successHandler(req, res, next);
+      expect(res.redirect.calledOnce).to.be.true;
+      expect(res.redirect.calledWith(`${req.baseUrl}/no-details-amend`)).to.be.true;
+      expect(req.sessionModel.set.calledWith('test-field-name', 'no'));
+    });
+
+    it('current fields answer is - no - should redirect to the given redirect /countersignatory-details - ', () => {
+      req = {
+        sessionModel: {
+          set: sinon.spy(),
+          get: fieldName => req.sessionModel[fieldName],
+          'test-field-name-three': 'yes',
+          'test-field-name-two': 'yes',
+          'test-field-name': 'no'
+        },
+        originalUrl: 'http://domain/path',
+        baseUrl: '/amend',
+        currentField: 'amend-change-substances-options',
+        form: {
+          values: {
+            'amend-change-substances-options': 'no'
+          }
+        }
+      };
+      instance = new (Behaviour('amend-change-substances-options', [
+        'test-field-name',
+        'test-field-name-two',
+        'test-field-name-three'])(Base))();
+      instance.successHandler(req, res, next);
+      expect(res.redirect.calledOnce).to.be.true;
+      expect(res.redirect.calledWith(`${req.baseUrl}/countersignatory-details`)).to.be.true;
+      expect(req.sessionModel.set.calledWith('test-field-name', 'no'));
+    });
+
+    it('current fields answer is - yes - should redirect to the next step - ', () => {
+      req = {
+        sessionModel: {
+          get: sinon.stub().returns('yes'),
+          'test-field-name': 'yes'
+        },
+        originalUrl: 'http://domain/path',
+        baseUrl: '/amend',
+        form: {
+          values: {
+            'test-field-name': 'yes'
+          }
+        }
+      };
+      instance.successHandler(req, res, next);
+      expect(res.redirect.calledOnce).to.be.false;
+      sinon.assert.calledWithExactly(Base.prototype.successHandler, req, res, next);
+    });
+
+    afterEach(() => {
+      Base.prototype.successHandler.restore();
+    });
+  });
+});


### PR DESCRIPTION
## What? 
as per jira ticket [EPP-146](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-146) Create a CHANGE SUBSTANCES page 
## Why? 
to allow the user to be directed to change substance flow or to skip this step
## How? 
- add change-substances.html
- add fields in index.js, fields.json and pages.json and fiels/index.js
- add summary-data-section.js
- add some path to next page
## Testing?
n/a manual
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
