### PR TITLE
EPP-229 Routing Update

### DIFF
--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -164,7 +164,7 @@ module.exports = {
           }
         }
       ],
-      next: '/previous-addresses',
+      next: '/previous-address',
       locals: {
         sectionNo: {
           new: 3,


### PR DESCRIPTION
## What? 
[EPP-229](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-229) - Routing logic for home address page
## Why? 

After the design change, if the moved date no longer meets the 'more than 5 year' condition then the user should progress to the previous-address page.

## How? 
Routing is updated to /previous-address
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
