### PR TITLE
EPP-51 Upload conduct of certificate page

### DIFF
--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -296,7 +296,11 @@ module.exports = {
       }
     },
     '/upload-certificate-conduct': {
-      fields: [],
+      behaviours: [
+        SaveDocument('new-renew-certificate-conduct', 'file-upload'),
+        RemoveDocument('new-renew-certificate-conduct')
+      ],
+      fields: ['file-upload'],
       next: '/other-licences',
       locals: {
         sectionNo: {

--- a/apps/epp-new/sections/summary-data-sections.js
+++ b/apps/epp-new/sections/summary-data-sections.js
@@ -241,6 +241,22 @@ module.exports = {
         }
       },
       {
+        step: '/upload-certificate-conduct',
+        field: 'new-renew-certificate-conduct',
+        parse: (documents, req) => {
+          if (
+            req.sessionModel
+              .get('steps')
+              .includes('/upload-certificate-conduct') &&
+            documents?.length > 0
+          ) {
+            return documents.map(file => file.name);
+          }
+
+          return null;
+        }
+      },
+      {
         step: '/upload-driving-licence',
         field: 'new-renew-upload-driving-licence',
         parse: (documents, req) => {

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -132,6 +132,18 @@
     "files-uploaded": "Files uploaded",
     "uploading-document": "Uploading your document..."
   },
+  "upload-certificate-conduct": {
+    "header": "Upload certificate of good conduct (optional)",
+    "label": "Upload a file",
+    "hint": "Your file must be JPG, JPEG, PDF or PNG and be 25MB or less",
+    "paragraph1": "A certificate of good conduct is issued by the police in your country of nationality. It shows if you have a criminal record and details of any offences.",
+    "paragraph2": "Attach an image of your certificate of good conduct. The image must be ",
+    "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
+    "link-text" : "signed by your countersignatory (opens in a new tab).",
+    "uploading-document": "Document uploading",
+    "not-uploaded": "No files uploaded", 
+    "uploaded": "File uploaded" 
+  },
   "confirm": {
     "header": "Check your answers",
     "title": "Check your answers – Apply for an explosives precursors and poisons licence",
@@ -262,7 +274,10 @@
       },
       "new-renew-upload-driving-licence": {
         "label": "UK driving licence attachment"
-      }
+      },
+      "new-renew-certificate-conduct" :{
+        "label": "Certificate of good conduct attachment"
+     }
     },
     "complete": {
       "header": "Your submission has been sent",

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -188,7 +188,8 @@
     "maxNewRenewBritishPassport" : "You can only upload upto {{maxNewRenewBritishPassport}} files or less. Remove a file before uploading another",
     "maxNewRenewEuPassport" : "You can only upload upto {{maxNewRenewEuPassport}} files or less. Remove a file before uploading another",
     "maxNewRenewProofAddress" : "You can only upload upto {{maxNewRenewProofAddress}} files or less. Remove a file before uploading another",
-    "maxNewRenewDrivingLicence" : "You can only upload upto {{maxNewRenewDrivingLicence}} files or less. Remove a file before uploading another"
+    "maxNewRenewDrivingLicence" : "You can only upload upto {{maxNewRenewDrivingLicence}} files or less. Remove a file before uploading another",
+    "maxNewRenewCertificateConduct" : "You can only upload upto {{maxNewRenewCertificateConduct}} files or less. Remove a file before uploading another"
   },
   "new-renew-previous-home-address-line1": {
     "required": "Enter address line 1, typically the building and street",

--- a/apps/epp-new/views/upload-certificate-conduct.html
+++ b/apps/epp-new/views/upload-certificate-conduct.html
@@ -1,0 +1,48 @@
+{{<partials-page}}
+{{$encoding}}enctype="multipart/form-data" name="file-upload-form" {{/encoding}}
+{{$page-content}}
+<p>{{#t}}pages.upload-certificate-conduct.paragraph1{{/t}}</p>
+   <p>{{#t}}pages.upload-certificate-conduct.paragraph2{{/t}}
+   <a class="govuk-link" href="{{#t}}pages.upload-certificate-conduct.link{{/t}}" rel="noreferrer noopener" target="_blank">{{#t}}pages.upload-certificate-conduct.link-text{{/t}}</a>
+</p>
+<div class="govuk-form-group" id="hofFileUpload">
+   <label class="govuk-label" for="file-upload">
+      <h2>{{#t}}pages.upload-certificate-conduct.label{{/t}}</h2>
+      <span class="govuk-hint">{{#t}}pages.upload-certificate-conduct.hint{{/t}}</span>
+   </label>
+   <p id="file-upload-error-maxFileSize" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.maxFileSize{{/t}}
+   </p>
+   <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
+   </p>
+   <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="new-renew-certificate-conduct">
+   <div id="upload-page-loading-spinner" class="spinner-container">
+      <div class="spinner-loader"></div>
+      <span class="spinner-message">{{#t}}pages.upload-certificate-conduct.uploading-document{{/t}}</span>
+   </div>
+</div>
+{{^values.new-renew-certificate-conduct}}
+<h2 class="govuk-heading-m">{{#t}}pages.upload-certificate-conduct.not-uploaded{{/t}}</h2>
+{{/values.new-renew-certificate-conduct}}
+{{#values.new-renew-certificate-conduct.length}}
+<h2 class="govuk-heading-m">{{#t}}pages.upload-certificate-conduct.uploaded{{/t}}</h2>
+<div id="uploaded-documents" class="govuk-width-container">
+   {{#values.new-renew-certificate-conduct}}
+   <div class="govuk-grid-row">
+       <div class="govuk-grid-column-three-quarters">
+           {{name}}
+       </div>
+       <div class="govuk-grid-column-one-quarter">
+           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+       </div>
+   </div>
+   <div class="file-upload-hrline"></div>
+   {{/values.new-renew-certificate-conduct}}
+</div>
+{{/values.new-renew-certificate-conduct.length}}
+<button class="govuk-button" name="optionalFileUpload" value="new-renew-certificate-conduct">
+   {{#t}}buttons.continue{{/t}}
+</button>
+{{/page-content}}
+{{/partials-page}}

--- a/config.js
+++ b/config.js
@@ -100,6 +100,11 @@ module.exports = {
         allowMultipleUploads: false,
         limit: 1,
         limitValidationError: 'maxNewRenewDrivingLicence'
+      },
+      'new-renew-upload-certificate-conduct': {
+        allowMultipleUploads: false,
+        limit: 1,
+        limitValidationError: 'maxNewRenewCertificateConduct'
       }
     }
   },


### PR DESCRIPTION
## What? 
[EPP-51](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-51) - Create Upload conduct of certificate page for new & renew flow - EPP

## Why? 
Allows user to upload a file

## How? 
- Added upload button and remove
- Added validations for page

## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging