### PR TITLE
EPP-191 Create upload british passport page replace

### DIFF
--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -1,6 +1,8 @@
 const validateAndRedirect = require('./behaviours/home-redirection');
 const SummaryPageBehaviour = require('hof').components.summary;
 const RemoveEditMode = require('../epp-common/behaviours/remove-edit-mode');
+const SaveDocument = require('../epp-common/behaviours/save-document');
+const RemoveDocument = require('../epp-common/behaviours/remove-document');
 
 module.exports = {
   name: 'EPP form',
@@ -78,10 +80,14 @@ module.exports = {
     },
     '/section-eleven': {
       fields: ['replace-which-document-type'],
-      next: '/section-twelve'
+      next: '/upload-british-passport'
     },
-    '/section-twelve': {
-      next: '/section-thirteen'
+    '/upload-british-passport': {
+      behaviours: [SaveDocument('replace-british-passport', 'file-upload'), RemoveDocument('replace-british-passport')],
+      fields: ['file-upload'],
+      continueOnEdit: true,
+      next: '/section-thirteen',
+      locals: { captionHeading: 'Section 12 of 26' }
     },
     '/section-thirteen': {
       fields: [

--- a/apps/epp-replace/sections/summary-data-sections.js
+++ b/apps/epp-replace/sections/summary-data-sections.js
@@ -1,1 +1,19 @@
+'use strict';
 
+module.exports = {
+  'replace-new-name-details': {
+    steps: [
+      {
+        step: '/upload-british-passport',
+        field: 'replace-british-passport',
+        parse: (documents, req) => {
+          if (
+            req.sessionModel.get('steps').includes('/upload-british-passport') && documents?.length > 0) {
+            return documents.map(file => file.name);
+          }
+          return null;
+        }
+      }
+    ]
+  }
+};

--- a/apps/epp-replace/translations/src/en/buttons.json
+++ b/apps/epp-replace/translations/src/en/buttons.json
@@ -1,3 +1,5 @@
 {
-"start": "initial button"
+"start": "initial button",
+"remove": "Remove",
+"continue": "Continue"
 }

--- a/apps/epp-replace/translations/src/en/pages.json
+++ b/apps/epp-replace/translations/src/en/pages.json
@@ -1,5 +1,33 @@
 {
     "application-submitted": {
         "confirmed": "Replaced application submitted"
+      },
+      "upload-british-passport" : {
+        "header": "Upload British passport",
+        "label": "Upload a file",
+        "hint": "Your file must be JPEG, PDF or PNG and be 25MB or less",
+        "paragraph1": "Attach an image of your British passport as proof of your identity. the image must be",
+        "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
+        "link-text" : "signed by your countersignatory (opens in a new tab).",
+        "uploading-document": "Uploading your document..",
+        "not-uploaded": "No files uploaded", 
+        "uploaded": "Files uploaded" 
+      },
+      "confirm": {
+        "header": "Check your answers",
+        "subheader": "Review your answers below and amend if required before proceeding to declaration and payment.",
+        "sections": {
+          "replace-british-passport": {
+            "header": "British passport attachment"
+          },
+          "replace-new-name-details": {
+            "header": "Countersignatory details"
+          }
+        },
+      "fields": {
+        "replace-british-passport" : {
+          "label": "British passport attachment"
+        }
       }
+    }
 }

--- a/apps/epp-replace/translations/src/en/validation.json
+++ b/apps/epp-replace/translations/src/en/validation.json
@@ -1,1 +1,8 @@
-{}
+{
+    "file-upload": {
+        "required": "Select a file to upload",
+        "maxFileSize": "The selected file must 25MB or smaller",
+        "fileType": "The selected file must be a JPG, PDF or PNG",
+        "maxAmendBritishPassport": "You can only upload up to {{maxAmendBritishPassport}} files or less. Remove a file before uploading another "
+      }
+}

--- a/apps/epp-replace/views/confirm.html
+++ b/apps/epp-replace/views/confirm.html
@@ -1,0 +1,11 @@
+{{<partials-page}}
+ {{$page-content}}
+  <div>
+    <p class="govuk-body">{{#t}}pages.confirm.subheader{{/t}}</p>
+  </div>
+    {{#rows}}
+      {{> partials-summary-table}}
+    {{/rows}}
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/epp-replace/views/upload-british-passport.html
+++ b/apps/epp-replace/views/upload-british-passport.html
@@ -1,0 +1,48 @@
+{{<partials-page}}
+{{$encoding}}enctype="multipart/form-data" name="file-upload-form" {{/encoding}}
+{{$page-content}}
+<p>{{#t}}pages.upload-british-passport.paragraph1{{/t}}
+   <a class="govuk-link" href="{{#t}}pages.upload-british-passport.link{{/t}}" rel="noreferrer noopener" target="_blank">{{#t}}pages.upload-british-passport.link-text{{/t}}</a>
+</p>
+<div class="govuk-form-group" id="hofFileUpload">
+   <label class="govuk-label" for="file-upload">
+      <h2>{{#t}}pages.upload-british-passport.label{{/t}}</h2>
+      <span class="govuk-hint">{{#t}}pages.upload-british-passport.hint{{/t}}</span>
+   </label>
+   <p id="file-upload-error-maxFileSize" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.maxFileSize{{/t}}
+   </p>
+   <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
+      <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
+   </p>
+   <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="replace-british-passport">
+   <div id="upload-page-loading-spinner" class="spinner-container">
+      <div class="spinner-loader"></div>
+      <span class="spinner-message">{{#t}}pages.upload-british-passport.uploading-document{{/t}}</span>
+   </div>
+</div>
+{{^values.replace-british-passport}}
+<h2 class="govuk-heading-m">{{#t}}pages.upload-british-passport.not-uploaded{{/t}}</h2>
+{{/values.replace-british-passport}}
+{{#values.replace-british-passport.length}}
+<br>
+<h2 class="govuk-heading-m">{{#t}}pages.upload-british-passport.uploaded{{/t}}</h2>
+<div id="uploaded-documents" class="govuk-width-container">
+   {{#values.replace-british-passport}}
+   <div class="govuk-grid-row">
+       <div class="govuk-grid-column-three-quarters">
+           {{name}}
+       </div>
+       <div class="govuk-grid-column-one-quarter">
+           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+       </div>
+   </div>
+   <div class="file-upload-hrline"></div>
+   {{/values.replace-british-passport}}
+</div>
+{{/values.replace-british-passport.length}}
+<button class="govuk-button" name="requireFileUpload" value="replace-british-passport">
+   {{#t}}buttons.continue{{/t}}
+</button>
+{{/page-content}}
+{{/partials-page}}

--- a/config.js
+++ b/config.js
@@ -100,6 +100,11 @@ module.exports = {
         allowMultipleUploads: false,
         limit: 1,
         limitValidationError: 'maxNewRenewDrivingLicence'
+      },
+      'replace-british-passport': {
+        allowMultipleUploads: false,
+        limit: 1,
+        limitValidationError: 'maxAmendBritishPassport'
       }
     }
   },


### PR DESCRIPTION
## What? 
[EPP-191](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-191) - Create upload British passport page for REPLACE flow - EPP

## Why? 
Allows user to upload a passport

## How? 
- Added upload functionality
- Added validations for page

## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging