### PR TITLE
EPP-168 REGULATED POISONS

### DIFF
--- a/apps/epp-amend/fields/index.js
+++ b/apps/epp-amend/fields/index.js
@@ -402,6 +402,15 @@ module.exports = {
     },
     attributes: [{ attribute: 'rows', value: 5 }]
   },
+  'amend-poisons-option': {
+    mixin: 'radio-group',
+    legend: {
+      className: 'govuk-label--m'
+    },
+    className: ['govuk-radios', 'govuk-radios--inline'],
+    options: ['yes', 'no'],
+    validate: 'required'
+  },
   'amend-poison': {
     mixin: 'select',
     validate: ['required'],

--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -14,6 +14,7 @@ const UploadFileCounter = require('../epp-common/behaviours/uploaded-files-count
 const DobUnder18Redirect = require('../epp-common/behaviours/dob-under18-redirect');
 const DeleteRedundantDocuments = require('../epp-common/behaviours/delete-redundant-documents');
 const JourneyValidator = require('../epp-common/behaviours/journey-validator');
+const CheckAndRedirect = require('../epp-common/behaviours/check-answer-redirect');
 
 module.exports = {
   name: 'EPP form',
@@ -287,7 +288,20 @@ module.exports = {
       locals: { captionHeading: 'Section 15 of 23' }
     },
     '/poisons': {
+      behaviours: [
+        CheckAndRedirect('amend-poisons-option',
+          ['amend-poisons-option', 'amend-regulated-explosives-precursors']
+        )],
       fields: ['amend-poisons-option'],
+      forks: [
+        {
+          target: '/countersignatory-details',
+          condition: {
+            field: 'amend-name-options',
+            value: 'no'
+          }
+        }
+      ],
       locals: { captionHeading: 'Section 16 of 23' },
       next: '/select-poisons'
     },
@@ -295,6 +309,9 @@ module.exports = {
       fields: ['amend-poison'],
       locals: { captionHeading: 'Section 17 of 23' },
       next: '/countersignatory-details'
+    },
+    '/no-poisons-or-precursors': {
+      field: []
     },
     '/countersignatory-details': {
       fields: [

--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -14,7 +14,6 @@ const UploadFileCounter = require('../epp-common/behaviours/uploaded-files-count
 const DobUnder18Redirect = require('../epp-common/behaviours/dob-under18-redirect');
 const DeleteRedundantDocuments = require('../epp-common/behaviours/delete-redundant-documents');
 const JourneyValidator = require('../epp-common/behaviours/journey-validator');
-const CheckAndRedirect = require('../epp-common/behaviours/check-answer-redirect');
 
 module.exports = {
   name: 'EPP form',

--- a/apps/epp-amend/translations/src/en/fields.json
+++ b/apps/epp-amend/translations/src/en/fields.json
@@ -164,13 +164,24 @@
       "none_selected": "Select"
     }
   },
+  "amend-poisons-option": {
+    "legend":"Does your licence need to cover poisons?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
   "amend-poison": {
     "hint": "Select a poison",
       "options":{
         "none_selected": "Select poison"
     }
   },
-  "amend-countersignatory-title":{
+  "amend-countersignatory-title": {
     "label": "Title",
     "options": {
       "none_selected": "Select"

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -121,6 +121,13 @@
   "precursor-details":{
     "header": "{{values.amend-precursor-field}}"
   },
+  "poisons": {
+    "header": "Regulated poisons",
+    "p1": "Check what your licence needs to cover using the",
+    "link": "https://www.gov.uk/government/publications/supplying-explosives-precursors/list-of-chemicals#regulated-poisons",
+    "link-text" : "list of regulated chemicals (opens in a new tab)",
+    "p2": "You do not need a licence for reportable poisons."
+  },
   "select-poisons": {
     "header": "Poisons",
     "p1": "Tell us which poisons you want to import acquire use or possess.",

--- a/apps/epp-amend/translations/src/en/validation.json
+++ b/apps/epp-amend/translations/src/en/validation.json
@@ -203,6 +203,9 @@
     "textAreaDefaultLength": "Usage address must be 2,000 characters or less",
     "notUrl" : "Your answer must not include a URL"
   },
+  "amend-poisons-option": {
+    "required": "Select if your licence needs to cover poisons"
+  },
   "amend-poison":{
     "required": "Select a poison"
   },

--- a/apps/epp-amend/views/poisons.html
+++ b/apps/epp-amend/views/poisons.html
@@ -1,0 +1,16 @@
+{{<partials-page}}
+  {{$page-content}}
+   <div>
+    <p class="govuk-body">{{#t}}pages.poisons.p1{{/t}}
+        <a class="govuk-link" href="{{#t}}pages.poisons.link{{/t}}" rel="noreferrer noopener" target="_blank">{{#t}}pages.poisons.link-text{{/t}}</a>.
+    </p>
+    <p class="govuk-body">{{#t}}pages.poisons.p2{{/t}}</p>
+   </div>
+  {{#fields}}
+    {{#renderField}}{{/renderField}}
+  {{/fields}}
+
+  {{#input-submit}}continue{{/input-submit}} 
+  
+  {{/page-content}}
+  {{/partials-page}}

--- a/apps/epp-common/behaviours/check-answer-redirect.js
+++ b/apps/epp-common/behaviours/check-answer-redirect.js
@@ -3,6 +3,9 @@ module.exports = (currentField, fieldsArray) => superclass =>
     successHandler(req, res, next) {
       const allFieldsNo = fieldsArray.every(fieldsArrayValue => req.sessionModel.get(fieldsArrayValue) === 'no');
       if (allFieldsNo) {
+        if(currentField === 'amend-poisons-option' || currentField === 'amend-regulated-explosives-precursors') {
+          return res.redirect(`${req.baseUrl}/no-poisons-or-precursors`);
+        }
         return res.redirect(`${req.baseUrl}/no-details-amend`);
       }
       return super.successHandler(req, res, next);


### PR DESCRIPTION
## What? 
create regulated poisons page as per jira ticket [EPP-168](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-168)
## Why? 
to give user the possibility to select if want to add poisons to the licence
## How? 
- add fields/index.js, fields.json, pages.json, validation.js
- add poisons.html
- update index.js
- update summary-data-section.js
- update check-answer-redirect.js
## Testing?
will be added after merging PR [76](https://github.com/UKHomeOffice/explosives-precursors-poisons/pull/76) is merged since `check-answer-redirect.js` belongs to that change
## Screenshots (optional)
## Anything Else? (optional)
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
