### PR TITLE
EPP-155 countersignatory-id

### DIFF
--- a/apps/epp-amend/fields/index.js
+++ b/apps/epp-amend/fields/index.js
@@ -503,6 +503,67 @@ module.exports = {
     className: ['govuk-input'],
     labelClassName: 'govuk-label--m'
   },
+  'amend-countersignatory-Id-type': {
+    isPageHeading: true,
+    mixin: 'radio-group',
+    validate: ['required'],
+    options: [
+      {
+        value: 'UK-passport',
+        toggle: 'amend-countersignatory-UK-passport-number',
+        child: 'input-text'
+      },
+      {
+        value: 'EU-passport',
+        toggle: 'amend-countersignatory-EU-passport-number',
+        child: 'input-text'
+      },
+      {
+        value: 'Uk-driving-licence',
+        toggle: 'amend-countersignatory-Uk-driving-licence-number',
+        child: 'input-text'
+      }
+    ]
+  },
+  'amend-countersignatory-UK-passport-number': {
+    validate: [
+      'required',
+      { type: 'maxlength', arguments: 9 },
+      'alphanum',
+      'notUrl'
+    ],
+    className: ['govuk-input', 'govuk-!-width-one-thirds'],
+    dependent: {
+      field: 'amend-countersignatory-Id-type',
+      value: 'UK-passport'
+    }
+  },
+  'amend-countersignatory-EU-passport-number': {
+    validate: [
+      'required',
+      { type: 'maxlength', arguments: 9 },
+      'alphanum',
+      'notUrl'
+    ],
+    className: ['govuk-input', 'govuk-!-width-one-thirds'],
+    dependent: {
+      field: 'amend-countersignatory-Id-type',
+      value: 'EU-passport'
+    }
+  },
+  'amend-countersignatory-Uk-driving-licence-number': {
+    validate: [
+      'required',
+      'notUrl',
+      { type: 'minlength', arguments: 16 },
+      helpers.isValidUkDrivingLicenceNumber
+    ],
+    className: ['govuk-input', 'govuk-!-width-one-thirds'],
+    dependent: {
+      field: 'amend-countersignatory-Id-type',
+      value: 'Uk-driving-licence'
+    }
+  },
   'amend-declaration': {
     mixin: 'checkbox',
     validate: ['required']

--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -1,7 +1,7 @@
 const validateAndRedirect = require('./behaviours/home-redirection');
 const SummaryPageBehaviour = require('hof').components.summary;
 const ValidateLicenceNumber = require('../epp-common/behaviours/licence-validator');
-const PostcodeValidation = require('../../utilities/helpers//postcode-validation');
+const PostcodeValidation = require('../../utilities/helpers/postcode-validation');
 const RemoveEditMode = require('../epp-common/behaviours/remove-edit-mode');
 const AfterDateOfBirth = require('../epp-common/behaviours/after-date-validator');
 const SaveDocument = require('../epp-common/behaviours/save-document');
@@ -9,8 +9,8 @@ const RemoveDocument = require('../epp-common/behaviours/remove-document');
 const DobEditRedirect = require('../epp-common/behaviours/dob-edit-redirect');
 const RenderPrecursorDetails = require('../epp-common/behaviours/render-precursors-detail');
 const SaveHomeAddress = require('../epp-common/behaviours/save-home-address');
-
 const UploadFileCounter = require('../epp-common/behaviours/uploaded-files-counter');
+const DobUnder18Redirect = require('../epp-common/behaviours/dob-under18-redirect');
 
 const DeleteRedundantDocuments = require('../epp-common/behaviours/delete-redundant-documents');
 
@@ -310,12 +310,18 @@ module.exports = {
         'amend-countersignatory-email'
       ],
       locals: { captionHeading: 'Section 20 of 23' },
-      next: '/section-eighteen'
+      next: '/countersignatory-id'
     },
-    '/section-eighteen': {
-      fields: ['amend-countersignatory-document-type'],
-      next: '/birth-certificate',
-      locals: { captionHeading: 'Section 21 of 23' }
+    '/countersignatory-id': {
+      behaviours: [DobUnder18Redirect('amend-date-of-birth', '/birth-certificate')],
+      fields: [
+        'amend-countersignatory-Id-type',
+        'amend-countersignatory-UK-passport-number',
+        'amend-countersignatory-EU-passport-number',
+        'amend-countersignatory-Uk-driving-licence-number'
+      ],
+      locals: { captionHeading: 'Section 21 of 23' },
+      next: '/birth-certificate'
     },
     '/birth-certificate': {
       behaviours: [

--- a/apps/epp-amend/sections/summary-data-sections.js
+++ b/apps/epp-amend/sections/summary-data-sections.js
@@ -345,6 +345,22 @@ module.exports = {
         field: 'amend-countersignatory-email'
       },
       {
+        step: '/countersignatory-id',
+        field: 'amend-countersignatory-Id-type'
+      },
+      {
+        step: '/countersignatory-id',
+        field: 'amend-countersignatory-UK-passport-number'
+      },
+      {
+        step: '/countersignatory-id',
+        field: 'amend-countersignatory-EU-passport-number'
+      },
+      {
+        step: '/countersignatory-id',
+        field: 'amend-countersignatory-Uk-driving-licence-number'
+      },
+      {
         step: '/birth-certificate',
         field: 'amend-birth-certificate',
         parse: (documents, req) => {

--- a/apps/epp-amend/translations/src/en/fields.json
+++ b/apps/epp-amend/translations/src/en/fields.json
@@ -261,6 +261,34 @@
     "label": "{{values.usePrecursorOtherAddressLabel}}",
     "hint": "Enter a UK address"
   },
+  "amend-countersignatory-Id-type": {
+    "legend": "Which identity document do you want to use?",
+    "hint": "If your licence is granted, you will need to show this document when buying the substances",
+    "options": {
+      "UK-passport": {
+        "label": "British passport"
+      },
+      "EU-passport": {
+        "label": "Passport from the EU, Switzerland, Norway, Iceland or Liechtenstein"
+      },
+      "Uk-driving-licence": {
+        "label": "UK driving licence",
+        "hint": "Must be a photocard licence."
+      }
+    }
+  },
+  "amend-countersignatory-UK-passport-number": {
+    "label": "What is your passport number?",
+    "hint" : "For example, 120897A"    
+  },
+  "amend-countersignatory-EU-passport-number": {
+    "label": "What is your passport number?",
+    "hint" : "For example, 120897A"  
+  },
+  "amend-countersignatory-Uk-driving-licence-number": {
+    "label": "What is your driving licence number?",
+    "hint" : "On section 5 of your licence, for example MORGA657054SM9IJ"    
+  },
   "amend-declaration": {
     "label": "I have read and agree to this declaration"
   }

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -301,6 +301,18 @@
       },
       "amend-poison": {
         "label": "Poisons"
+      },
+      "amend-countersignatory-Id-type": {
+        "label": "Identification document"
+      },
+      "amend-countersignatory-UK-passport-number": {
+        "label": "British passport number"
+      },
+      "amend-countersignatory-EU-passport-number": {
+        "label": "Passport number"
+      },
+      "amend-countersignatory-Uk-driving-licence-number": {
+        "label": "UK driving licence number"
       }
     }
   }

--- a/apps/epp-amend/translations/src/en/validation.json
+++ b/apps/epp-amend/translations/src/en/validation.json
@@ -263,6 +263,28 @@
     "required": "Enter your countersignatory's email address",
     "email": "Enter a real email address"
   },
+  "amend-countersignatory-Id-type": {
+    "required": "Select which identity document you want to use"
+  },
+  "amend-countersignatory-UK-passport-number": {
+    "required": "Enter your passport number",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer",
+    "maxlength": "Passport number must be 9 characters or less",
+    "alphanum": "Passport number must only include numbers and letters a-z"
+    
+  },
+  "amend-countersignatory-EU-passport-number": {
+    "required": "Enter your passport number",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer", 
+    "maxlength": "Passport number must be 9 characters or less",
+    "alphanum": " Passport number must only include numbers and letters a-z"
+  },
+  "amend-countersignatory-Uk-driving-licence-number": {
+    "required": "Enter your driving licence number",
+    "isValidUkDrivingLicenceNumber": "Enter a real UK driving licence number",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer",
+    "minlength": "Driving licence number must be 16 characters"
+  }, 
   "amend-declaration": {
     "required": "Confirm you have read and agree to this declaration"
   }

--- a/apps/epp-common/behaviours/dob-under18-redirect.js
+++ b/apps/epp-common/behaviours/dob-under18-redirect.js
@@ -1,0 +1,18 @@
+const {
+  isDateOlderOrEqualTo
+} = require('../../../utilities/helpers');
+
+/**
+ * @param {string} field - The field name whose value need to be validated and saved
+ * @param {string} redirectTo - The path to redirect to if the conditions are met
+ */
+module.exports = (field, redirectTo) => superclass =>
+  class extends superclass {
+    successHandler(req, res, next) {
+      const enteredDob = req.sessionModel.get(field);
+      if (enteredDob && !isDateOlderOrEqualTo(enteredDob, 18)) {
+        return res.redirect(req.baseUrl + redirectTo);
+      }
+      return super.successHandler(req, res, next);
+    }
+  };


### PR DESCRIPTION
## What? 
create countersignatory-id page as per jira ticket [EPP-155](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-155)
## Why? 
To  give the opportunity, to the user to provide the countersignatory document number.
## How? 
- add fields in index.js, fields/index.js field.json, pages.jon and validation.json
- add section in summary-data-sections.js
## Testing?
manual
## Screenshots (optional)
## Anything Else? (optional)
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
