### PR TITLE
EPP-227 File counter and min files error

### DIFF
--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -10,6 +10,8 @@ const DobEditRedirect = require('../epp-common/behaviours/dob-edit-redirect');
 const RenderPrecursorDetails = require('../epp-common/behaviours/render-precursors-detail');
 const SaveHomeAddress = require('../epp-common/behaviours/save-home-address');
 
+const UploadFileCounter = require('../epp-common/behaviours/uploaded-files-counter');
+
 module.exports = {
   name: 'EPP form',
   fields: 'apps/epp-amend/fields',
@@ -202,7 +204,8 @@ module.exports = {
     '/upload-proof-address': {
       behaviours: [
         SaveDocument('amend-proof-address', 'file-upload'),
-        RemoveDocument('amend-proof-address')
+        RemoveDocument('amend-proof-address'),
+        UploadFileCounter('amend-proof-address')
       ],
       fields: ['file-upload'],
       continueOnEdit: true,

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -35,7 +35,7 @@
     "paragraph1": "Attach an image of your British passport as proof of your identity. The image must be",
     "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
     "link-text": "signed by your countersignatory (opens in a new tab).",
-    "uploading-document": "Document uploading",
+    "uploading-document": "Uploading your document...",
     "not-uploaded": "No file uploaded", 
     "uploaded": "Files uploaded" 
   },
@@ -56,9 +56,11 @@
     "paragraph3-li5": "benefit statement",
     "label": "Upload a file",
     "hint": "Your file must be JPG, JPEG, PDF or PNG and be 25MB or less",
-    "uploading-document": "Document uploading",
+    "uploading-document": "Uploading your document...",
     "not-uploaded": "No file uploaded", 
-    "uploaded": "Files uploaded" 
+    "uploaded": "Files uploaded",
+    "counter-of": "of",
+    "counter-files-uploaded": "files uploaded"
   },
   "upload-passport": {
     "header": "Upload passport",
@@ -67,7 +69,7 @@
     "paragraph1": "Attach an image of your passport from the EU, Switzerland, Norway, Iceland or Liechtenstein as proof of your identity. The image must be ",
     "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
     "link-text" : "signed by your countersignatory (opens in a new tab).",
-    "uploading-document": "Document uploading",
+    "uploading-document": "Uploading your document...",
     "not-uploaded": "No files uploaded", 
     "uploaded": "File uploaded" 
   },
@@ -79,7 +81,7 @@
     "paragraph2": "Attach an image of your certificate of good conduct. The image must be ",
     "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
     "link-text" : "signed by your countersignatory (opens in a new tab).",
-    "uploading-document": "Document uploading",
+    "uploading-document": "Uploading your document...",
     "not-uploaded": "No files uploaded", 
     "uploaded": "File uploaded" 
   },
@@ -90,7 +92,7 @@
     "paragraph1": "Attach an image of your driving licence photocard as proof of your identity. The image must be",
     "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
     "link-text" : "signed by your countersignatory (opens in a new tab).",
-    "uploading-document": "Document uploading",
+    "uploading-document": "Uploading your document...",
     "not-uploaded": "No files uploaded", 
     "uploaded": "File uploaded" 
   },

--- a/apps/epp-amend/translations/src/en/validation.json
+++ b/apps/epp-amend/translations/src/en/validation.json
@@ -91,6 +91,7 @@
       }, 
       "file-upload": {
         "required": "Select a file to upload",
+        "upload-min-files-error": "You must upload at least 2 files",
         "maxFileSize": "The selected file must 25MB or smaller",
         "fileType": "The selected file must be a JPG, JPEG, PDF or PNG",
         "maxAmendBritishPassport": "You can only upload up to {{maxAmendBritishPassport}} files or less. Remove a file before uploading another",

--- a/apps/epp-amend/views/upload-british-passport.html
+++ b/apps/epp-amend/views/upload-british-passport.html
@@ -33,7 +33,7 @@
            {{name}}
        </div>
        <div class="govuk-grid-column-one-quarter">
-           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}<span class="visuallyhidden">{{name}}</span></a>
        </div>
    </div>
    <div class="file-upload-hrline"></div>

--- a/apps/epp-amend/views/upload-certificate-conduct.html
+++ b/apps/epp-amend/views/upload-certificate-conduct.html
@@ -34,7 +34,7 @@
            {{name}}
        </div>
        <div class="govuk-grid-column-one-quarter">
-           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}<span class="visuallyhidden">{{name}}</span></a>
        </div>
    </div>
    <div class="file-upload-hrline"></div>

--- a/apps/epp-amend/views/upload-driving-licence.html
+++ b/apps/epp-amend/views/upload-driving-licence.html
@@ -33,7 +33,7 @@
            {{name}}
        </div>
        <div class="govuk-grid-column-one-quarter">
-           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}<span class="visuallyhidden">{{name}}</span></a>
        </div>
    </div>
    <div class="file-upload-hrline"></div>

--- a/apps/epp-amend/views/upload-passport.html
+++ b/apps/epp-amend/views/upload-passport.html
@@ -33,7 +33,7 @@
            {{name}}
        </div>
        <div class="govuk-grid-column-one-quarter">
-           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}<span class="visuallyhidden">{{name}}</span></a>
        </div>
    </div>
    <div class="file-upload-hrline"></div>

--- a/apps/epp-amend/views/upload-proof-address.html
+++ b/apps/epp-amend/views/upload-proof-address.html
@@ -34,6 +34,13 @@
     <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
         <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
     </p>
+
+    {{#requiredDocsCount}}
+    {{#values.amend-proof-address.length}}
+        <p class="govuk-body">{{values.amend-proof-address.length}} {{#t}}pages.upload-proof-address.counter-of{{/t}} {{requiredDocsCount}} {{#t}}pages.upload-proof-address.counter-files-uploaded{{/t}}</p>
+    {{/values.amend-proof-address.length}}
+    {{/requiredDocsCount}}
+
     <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="amend-proof-address">
 
     <div id="upload-page-loading-spinner" class="spinner-container">
@@ -57,7 +64,7 @@
             {{name}}
         </div>
         <div class="govuk-grid-column-one-quarter">
-            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}} <span class="visuallyhidden">{{name}}</span></a>
         </div>
     </div>
     <div class="file-upload-hrline"></div>

--- a/apps/epp-common/behaviours/save-document.js
+++ b/apps/epp-common/behaviours/save-document.js
@@ -36,9 +36,19 @@ module.exports = (documentName, fieldName) => superclass =>
         throw new Error('Document configuration is not defined');
       }
 
-      if (req.body.requireFileUpload && documentsByCategory.length === 0) {
-        return validationErrorFunc('required');
-      } else if (fileToBeValidated) {
+      if (req.body.requireFileUpload) {
+        const documentsCount = documentsByCategory.length;
+        const minLimit = documentCategoryConfig.limit;
+        if (documentsCount === 0) {
+          return validationErrorFunc('required');
+        }
+
+        if (documentsCount < minLimit) {
+          return validationErrorFunc('upload-min-files-error');
+        }
+      }
+
+      if (fileToBeValidated) {
         const uploadSize = fileToBeValidated.size;
         const mimetype = fileToBeValidated.mimetype;
         const uploadSizeTooBig = uploadSize > config.upload.maxFileSizeInBytes;

--- a/apps/epp-common/behaviours/uploaded-files-counter.js
+++ b/apps/epp-common/behaviours/uploaded-files-counter.js
@@ -1,0 +1,14 @@
+const { upload } = require('../../../config');
+
+module.exports = documentName => superclass =>
+  class extends superclass {
+    locals(req, res) {
+      const locals = super.locals(req, res);
+      const documentCategoryConfig = upload.documentCategories[documentName];
+      if (documentCategoryConfig?.limit >= 2) {
+        locals.requiredDocsCount = documentCategoryConfig.limit;
+      }
+
+      return locals;
+    }
+  };

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -17,6 +17,8 @@ const SaveDocument = require('../epp-common/behaviours/save-document');
 const RemoveDocument = require('../epp-common/behaviours/remove-document');
 const DobEditRedirect = require('../epp-common/behaviours/dob-edit-redirect');
 
+const UploadFileCounter = require('../epp-common/behaviours/uploaded-files-counter');
+
 module.exports = {
   name: 'EPP form',
   fields: 'apps/epp-new/fields',
@@ -206,7 +208,8 @@ module.exports = {
     '/upload-proof-address': {
       behaviours: [
         SaveDocument('new-renew-proof-address', 'file-upload'),
-        RemoveDocument('new-renew-proof-address')
+        RemoveDocument('new-renew-proof-address'),
+        UploadFileCounter('new-renew-proof-address')
       ],
       fields: ['file-upload'],
       next: '/contact-details',

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -119,7 +119,9 @@
     "file-format": "Your file must be JPEG, PDF or PNG, and be 25MB or less",
     "no-file-uploaded": "No files uploaded",
     "files-uploaded": "Files uploaded",
-    "uploading-document": "Uploading your document..."
+    "uploading-document": "Uploading your document...",
+    "counter-of": "of",
+    "counter-files-uploaded": "files uploaded"
   },
   "upload-driving-licence": {
     "header": "Upload UK driving licence",

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -182,6 +182,7 @@
   },
   "file-upload": {
     "required": "Select a file to upload",
+    "upload-min-files-error": "You must upload at least 2 files",
     "unsaved": "Your file could not be uploaded – try again",
     "maxFileSize": "The selected file must be 25MB or smaller",
     "fileType": "The selected file must be a JPG, JPEG, PDF or PNG",

--- a/apps/epp-new/views/birth-certificate.html
+++ b/apps/epp-new/views/birth-certificate.html
@@ -38,7 +38,7 @@
             {{name}}
         </div>
         <div class="govuk-grid-column-one-quarter">
-            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a><span class="visuallyhidden">{{name}}</span>
+            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}<span class="visuallyhidden">{{name}}</span></a>
         </div>
     </div>
     <div class="file-upload-hrline"></div>

--- a/apps/epp-new/views/medical-form.html
+++ b/apps/epp-new/views/medical-form.html
@@ -42,7 +42,7 @@
             {{name}}
         </div>
         <div class="govuk-grid-column-one-quarter">
-            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a><span class="visuallyhidden">{{name}}</span>
+            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}<span class="visuallyhidden">{{name}}</span></a>
         </div>
     </div>
     <div class="file-upload-hrline"></div>

--- a/apps/epp-new/views/upload-british-passport.html
+++ b/apps/epp-new/views/upload-british-passport.html
@@ -44,7 +44,7 @@
             {{name}}
         </div>
         <div class="govuk-grid-column-one-quarter">
-            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}<span class="visuallyhidden">{{name}}</span></a>
         </div>
     </div>
     <div class="file-upload-hrline"></div>

--- a/apps/epp-new/views/upload-certificate-conduct.html
+++ b/apps/epp-new/views/upload-certificate-conduct.html
@@ -34,7 +34,7 @@
            {{name}}
        </div>
        <div class="govuk-grid-column-one-quarter">
-           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}<span class="visuallyhidden">{{name}}</span></a>
        </div>
    </div>
    <div class="file-upload-hrline"></div>

--- a/apps/epp-new/views/upload-driving-licence.html
+++ b/apps/epp-new/views/upload-driving-licence.html
@@ -44,7 +44,7 @@
             {{name}}
         </div>
         <div class="govuk-grid-column-one-quarter">
-            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}<span class="visuallyhidden">{{name}}</span></a>
         </div>
     </div>
     <div class="file-upload-hrline"></div>

--- a/apps/epp-new/views/upload-passport.html
+++ b/apps/epp-new/views/upload-passport.html
@@ -40,7 +40,7 @@
             {{name}}
         </div>
         <div class="govuk-grid-column-one-quarter">
-            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}<span class="visuallyhidden">{{name}}</span></a>
         </div>
     </div>
     <div class="file-upload-hrline"></div>

--- a/apps/epp-new/views/upload-proof-address.html
+++ b/apps/epp-new/views/upload-proof-address.html
@@ -34,6 +34,14 @@
     <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
         <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
     </p>
+
+    {{#requiredDocsCount}}
+        {{#values.new-renew-proof-address.length}}
+            <p class="govuk-body">{{values.new-renew-proof-address.length}} {{#t}}pages.upload-proof-address.counter-of{{/t}} {{requiredDocsCount}} {{#t}}pages.upload-proof-address.counter-files-uploaded{{/t}}</p>
+        {{/values.new-renew-proof-address.length}}
+    {{/requiredDocsCount}}
+
+
     <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="new-renew-proof-address">
 
     <div id="upload-page-loading-spinner" class="spinner-container">

--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -5,6 +5,8 @@ const SaveDocument = require('../epp-common/behaviours/save-document');
 const RemoveDocument = require('../epp-common/behaviours/remove-document');
 const ValidateLicenceNumber = require('../epp-common/behaviours/licence-validator');
 
+const UploadFileCounter = require('../epp-common/behaviours/uploaded-files-counter');
+
 module.exports = {
   name: 'EPP form',
   fields: 'apps/epp-replace/fields',
@@ -139,7 +141,8 @@ module.exports = {
     '/upload-proof-address': {
       behaviours: [
         SaveDocument('replace-proof-address', 'file-upload'),
-        RemoveDocument('replace-proof-address')
+        RemoveDocument('replace-proof-address'),
+        UploadFileCounter('replace-proof-address')
       ],
       fields: ['file-upload'],
       locals: { captionHeading: 'Section 15 of 26' },

--- a/apps/epp-replace/translations/src/en/pages.json
+++ b/apps/epp-replace/translations/src/en/pages.json
@@ -53,7 +53,9 @@
     "file-format": "Your file must be JPEG, PDF or PNG, and be 25MB or less",
     "no-file-uploaded": "No files uploaded",
     "files-uploaded": "Files uploaded",
-    "uploading-document": "Uploading your document..."
+    "uploading-document": "Uploading your document...",
+    "counter-of": "of",
+    "counter-files-uploaded": "files uploaded"
   },
   "upload-certificate-conduct": {
     "header": "Upload certificate of good conduct (optional)",

--- a/apps/epp-replace/translations/src/en/validation.json
+++ b/apps/epp-replace/translations/src/en/validation.json
@@ -1,6 +1,7 @@
 {
   "file-upload": {
     "required": "Select a file to upload",
+    "upload-min-files-error": "You must upload at least 2 files",
     "maxFileSize": "The selected file must be 25MB or smaller",
     "fileType": "The selected file must be a JPG, JPEG, PDF or PNG",
     "maxReplaceBritishPassport": "You can only upload up to {{maxReplaceBritishPassport}} files or less. Remove a file before uploading another",

--- a/apps/epp-replace/views/upload-british-passport.html
+++ b/apps/epp-replace/views/upload-british-passport.html
@@ -34,7 +34,7 @@
            {{name}}
        </div>
        <div class="govuk-grid-column-one-quarter">
-           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}<span class="visuallyhidden">{{name}}</span></a>
        </div>
    </div>
    <div class="file-upload-hrline"></div>

--- a/apps/epp-replace/views/upload-certificate-conduct.html
+++ b/apps/epp-replace/views/upload-certificate-conduct.html
@@ -34,7 +34,7 @@
            {{name}}
        </div>
        <div class="govuk-grid-column-one-quarter">
-           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+           <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}<span class="visuallyhidden">{{name}}</span></a>
        </div>
    </div>
    <div class="file-upload-hrline"></div>

--- a/apps/epp-replace/views/upload-driving-licence.html
+++ b/apps/epp-replace/views/upload-driving-licence.html
@@ -44,7 +44,7 @@
             {{name}}
         </div>
         <div class="govuk-grid-column-one-quarter">
-            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}<span class="visuallyhidden">{{name}}</span></a>
         </div>
     </div>
     <div class="file-upload-hrline"></div>

--- a/apps/epp-replace/views/upload-passport.html
+++ b/apps/epp-replace/views/upload-passport.html
@@ -40,7 +40,7 @@
             {{name}}
         </div>
         <div class="govuk-grid-column-one-quarter">
-            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}<span class="visuallyhidden">{{name}}</span></a>
         </div>
     </div>
     <div class="file-upload-hrline"></div>

--- a/apps/epp-replace/views/upload-proof-address.html
+++ b/apps/epp-replace/views/upload-proof-address.html
@@ -34,6 +34,13 @@
     <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
         <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
     </p>
+
+    {{#requiredDocsCount}}
+    {{#values.replace-proof-address.length}}
+        <p class="govuk-body">{{values.replace-proof-address.length}} {{#t}}pages.upload-proof-address.counter-of{{/t}} {{requiredDocsCount}} {{#t}}pages.upload-proof-address.counter-files-uploaded{{/t}}</p>
+    {{/values.replace-proof-address.length}}
+    {{/requiredDocsCount}}
+
     <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="replace-proof-address">
 
     <div id="upload-page-loading-spinner" class="spinner-container">
@@ -57,7 +64,7 @@
             {{name}}
         </div>
         <div class="govuk-grid-column-one-quarter">
-            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}</a>
+            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}<span class="visuallyhidden">{{name}}</span></a>
         </div>
     </div>
     <div class="file-upload-hrline"></div>

--- a/test/unit/behaviours/uploaded-files-counter.spec.js
+++ b/test/unit/behaviours/uploaded-files-counter.spec.js
@@ -1,0 +1,62 @@
+const proxyquire = require('proxyquire');
+
+describe('uploaded-files-counter tests', () => {
+  let req;
+  let res;
+  let superclass;
+  let instance;
+  let uploadFilesCounter;
+
+  beforeEach(() => {
+    req = {
+      sessionModel: {
+        get: sinon.stub(),
+        set: sinon.stub()
+      },
+      form: {
+        values: {}
+      },
+      app: {
+        config: {
+          upload: {
+            documentCategories: {
+              testUploadDoc: {
+                limit: 1
+              }
+            }
+          }
+        }
+      }
+    };
+
+    res = {};
+    superclass = class {
+      locals() {
+        return {};
+      }
+    };
+
+    uploadFilesCounter = proxyquire(
+      '../../../apps/epp-common/behaviours/uploaded-files-counter',
+      {
+        '../../../config': {
+          upload: req.app.config.upload
+        }
+      }
+    );
+
+    instance = new (uploadFilesCounter('testUploadDoc')(superclass))();
+  });
+
+  it('should set the counter if the limit is more than 1', () => {
+    req.app.config.upload.documentCategories.testUploadDoc.limit = 2;
+    const locals = instance.locals(req, res);
+    expect(locals.requiredDocsCount).to.equal(2);
+  });
+
+  it('should not set the counter if the limit is less than 2', () => {
+    req.app.config.upload.documentCategories.testUploadDoc.limit = 1;
+    const locals = instance.locals(req, res);
+    expect(locals.requiredDocsCount).to.be.undefined;
+  });
+});


### PR DESCRIPTION
## What? 
[EPP-227](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-227) - File upload number counter and minimum validation
## Why? 
- File upload component improvement and accessibility bug
## How? 
- Updated file counter for pages require more than 1 file to be uploaded
- fixed accessibility bug with adding visually hidden text
## Testing?
Local and branch testing
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
