### PR TITLE
EPP-243 Remove redundant upload docs

### DIFF
--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -12,6 +12,8 @@ const SaveHomeAddress = require('../epp-common/behaviours/save-home-address');
 
 const UploadFileCounter = require('../epp-common/behaviours/uploaded-files-counter');
 
+const DeleteRedundantDocuments = require('../epp-common/behaviours/delete-redundant-documents');
+
 module.exports = {
   name: 'EPP form',
   fields: 'apps/epp-amend/fields',
@@ -73,6 +75,14 @@ module.exports = {
       next: '/amend-details'
     },
     '/amend-details': {
+      behaviours: [
+        DeleteRedundantDocuments('amend-name-options', [
+          'amend-british-passport',
+          'amend-eu-passport',
+          'amend-certificate-conduct',
+          'amend-uk-driving-licence'
+        ])
+      ],
       fields: ['amend-name-options'],
       forks: [
         {
@@ -167,6 +177,11 @@ module.exports = {
       locals: { captionHeading: 'Section 9 of 23' }
     },
     '/change-home-address': {
+      behaviours: [
+        DeleteRedundantDocuments('amend-home-address-options', [
+          'amend-proof-address'
+        ])
+      ],
       fields: ['amend-home-address-options'],
       forks: [
         {

--- a/apps/epp-common/behaviours/delete-redundant-documents.js
+++ b/apps/epp-common/behaviours/delete-redundant-documents.js
@@ -1,3 +1,12 @@
+/**
+ * Responsible for removing uploaded documents
+ * from the session when the related or dependent form field changes from 'yes' to 'no'
+ *
+ * @param {string} fieldName - The name of the form field to check.
+ * @param {string[]} uploadDocs - An array of field names representing uploaded documents.
+ * @returns {Function} - Returns a new class extending the superclass.
+ */
+
 module.exports = (fieldName, uploadDocs) => superclass =>
   class extends superclass {
     saveValues(req, res, next) {

--- a/apps/epp-common/behaviours/delete-redundant-documents.js
+++ b/apps/epp-common/behaviours/delete-redundant-documents.js
@@ -1,0 +1,16 @@
+module.exports = (fieldName, uploadDocs) => superclass =>
+  class extends superclass {
+    saveValues(req, res, next) {
+      const fieldSelectedNo = req.form.values[fieldName] === 'no';
+      if (fieldSelectedNo && Array.isArray(uploadDocs)) {
+        uploadDocs.forEach(uploadField => {
+          const uploadedDocuments = req.sessionModel.get(uploadField);
+          if (uploadedDocuments?.length) {
+            req.sessionModel.set(uploadField, []);
+          }
+        });
+      }
+
+      return super.saveValues(req, res, next);
+    }
+  };

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -19,6 +19,8 @@ const DobEditRedirect = require('../epp-common/behaviours/dob-edit-redirect');
 
 const UploadFileCounter = require('../epp-common/behaviours/uploaded-files-counter');
 
+const DeleteRedundantDocuments = require('../epp-common/behaviours/delete-redundant-documents');
+
 module.exports = {
   name: 'EPP form',
   fields: 'apps/epp-new/fields',
@@ -419,6 +421,11 @@ module.exports = {
       }
     },
     '/medical-history': {
+      behaviours: [
+        DeleteRedundantDocuments('new-renew-received-treatment', [
+          'new-renew-medical-form'
+        ])
+      ],
       fields: ['new-renew-has-seen-doctor', 'new-renew-received-treatment'],
       forks: [
         {

--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -7,6 +7,8 @@ const ValidateLicenceNumber = require('../epp-common/behaviours/licence-validato
 
 const UploadFileCounter = require('../epp-common/behaviours/uploaded-files-counter');
 
+// TODO: Use DeleteRedundantDocuments behaviour similar to amend flow to
+// remove the uploaded files when dependent option changes
 module.exports = {
   name: 'EPP form',
   fields: 'apps/epp-replace/fields',

--- a/test/unit/behaviours/delete-redundant-documents.spec.js
+++ b/test/unit/behaviours/delete-redundant-documents.spec.js
@@ -1,0 +1,70 @@
+const DeleteRedundantDocuments = require('../../../apps/epp-common/behaviours/delete-redundant-documents');
+
+describe('Tests for delete-redundant-documents behaviour', () => {
+  class Base {
+    constructor() {}
+    saveValues() {}
+  }
+
+  let req;
+  let res;
+  let instance;
+  const next = 'unit-test';
+
+  beforeEach(() => {
+    req = reqres.req();
+    res = reqres.res();
+  });
+  describe('saveValues tests', () => {
+    beforeEach(() => {
+      sinon.stub(Base.prototype, 'saveValues').returns(req, res, next);
+      instance = new (DeleteRedundantDocuments('test-fiel-name', [
+        'upload-test-1'
+      ])(Base))();
+    });
+
+    it('init - saveValues', () => {
+      instance.saveValues(req, res, next);
+      expect(Base.prototype.saveValues).to.have.been.called;
+    });
+
+    it('Should clear the uplaods from session when selected value is no', () => {
+      req = {
+        sessionModel: {
+          set: sinon.spy(),
+          get: () => ['upload-details']
+        },
+        form: {
+          values: {
+            'test-fiel-name': 'no'
+          }
+        }
+      };
+
+      instance.saveValues(req, res, next);
+      expect(req.sessionModel.set.calledOnce).to.be.true;
+      expect(req.sessionModel.set.calledWith('upload-test-1', [])).to.be.true;
+    });
+
+    it('Should not clear the uplaods from session when selected value is not no', () => {
+      req = {
+        sessionModel: {
+          set: sinon.spy(),
+          get: () => ['upload-details']
+        },
+        form: {
+          values: {
+            'test-fiel-name': 'yes'
+          }
+        }
+      };
+
+      instance.saveValues(req, res, next);
+      expect(req.sessionModel.set.calledOnce).to.be.false;
+    });
+
+    afterEach(() => {
+      Base.prototype.saveValues.restore();
+    });
+  });
+});


### PR DESCRIPTION
## What? 
[EPP-243](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-243)- Uploaded document still visible in summary page
## Why? 
An issue has been identified where upload documents are still visible after the related fields are updated from yes to no. 
## How? 
- Behaviour is added to delete the redundant documents
- TODO added in the replace flow so it can be addressed when we build the replace flow
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
