### PR TITLE
EPP-223 Updated base path - New Renew

### DIFF
--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -13,6 +13,7 @@ const CheckAndRedirect = require('../epp-common/behaviours/check-answer-redirect
 const UploadFileCounter = require('../epp-common/behaviours/uploaded-files-counter');
 const DobUnder18Redirect = require('../epp-common/behaviours/dob-under18-redirect');
 const DeleteRedundantDocuments = require('../epp-common/behaviours/delete-redundant-documents');
+const JourneyValidator = require('../epp-common/behaviours/journey-validator');
 
 module.exports = {
   name: 'EPP form',
@@ -20,6 +21,7 @@ module.exports = {
   views: 'apps/epp-amend/views',
   translations: 'apps/epp-amend/translations',
   baseUrl: '/amend',
+  behaviours: [JourneyValidator],
   steps: {
     '/licence-number': {
       behaviours: [validateAndRedirect, RemoveEditMode, ValidateLicenceNumber],

--- a/apps/epp-common/index.js
+++ b/apps/epp-common/index.js
@@ -13,7 +13,7 @@ module.exports = {
       fields: ['application-type'],
       forks: [
         {
-          target: '/new-and-renew/your-name',
+          target: '/new-renew/your-name',
           condition: {
             field: 'application-type',
             value: 'new'
@@ -27,7 +27,7 @@ module.exports = {
           }
         },
         {
-          target: '/new-and-renew/licence-number',
+          target: '/new-renew/licence-number',
           condition: {
             field: 'application-type',
             value: 'renew'

--- a/apps/epp-new/behaviours/check-back-link.js
+++ b/apps/epp-new/behaviours/check-back-link.js
@@ -7,8 +7,8 @@ module.exports = superclass =>
       if (locals?.route === 'your-name' && isRenewJourney) {
         const isEditMode = locals.backLink?.endsWith('/edit');
         locals.backLink = isEditMode
-          ? '/new-and-renew/licence-number/edit'
-          : '/new-and-renew/licence-number';
+          ? '/new-renew/licence-number/edit'
+          : '/new-renew/licence-number';
       }
       return locals;
     }

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -23,6 +23,7 @@ const DeleteRedundantDocuments = require('../epp-common/behaviours/delete-redund
 
 const InitiatePaymentRequest = require('../epp-common/behaviours/initiate-payment-request');
 const GetPaymentInfo = require('../epp-common/behaviours/get-payment-info');
+const JourneyValidator = require('../epp-common/behaviours/journey-validator');
 
 module.exports = {
   name: 'EPP form',
@@ -31,7 +32,7 @@ module.exports = {
   translations: 'apps/epp-new/translations',
   baseUrl: '/new-renew',
   params: '/:action?/:id?/:edit?',
-  behaviours: [sectionCounter],
+  behaviours: [sectionCounter, JourneyValidator],
   steps: {
     '/your-name': {
       behaviours: [

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -29,7 +29,7 @@ module.exports = {
   fields: 'apps/epp-new/fields',
   views: 'apps/epp-new/views',
   translations: 'apps/epp-new/translations',
-  baseUrl: '/new-and-renew',
+  baseUrl: '/new-renew',
   params: '/:action?/:id?/:edit?',
   behaviours: [sectionCounter],
   steps: {
@@ -107,7 +107,7 @@ module.exports = {
     },
     '/your-details': {
       behaviours: [
-        DobEditRedirect('new-renew-dob', '/new-and-renew/birth-certificate')
+        DobEditRedirect('new-renew-dob', '/new-renew/birth-certificate')
       ],
       fields: [
         'new-renew-dob',

--- a/apps/epp-new/sections/summary-data-sections.js
+++ b/apps/epp-new/sections/summary-data-sections.js
@@ -36,7 +36,7 @@ module.exports = {
       {
         step: '/other-names-summary',
         field: 'othernames',
-        changeLink: '/new-and-renew/other-names-summary',
+        changeLink: '/new-renew/other-names-summary',
         parse: (list, req) => {
           if (req.sessionModel.get('new-renew-other-names') === 'no') {
             return null;

--- a/apps/epp-renew/index.js
+++ b/apps/epp-renew/index.js
@@ -7,7 +7,7 @@ module.exports = {
   fields: 'apps/epp-renew/fields',
   views: 'apps/epp-renew/views',
   translations: 'apps/epp-renew/translations',
-  baseUrl: '/new-and-renew',
+  baseUrl: '/new-renew',
   steps: {
     '/licence-number': {
       behaviours: [validateAndRedirect, RemoveEditMode, ValidateLicenceNumber],

--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -6,6 +6,7 @@ const RemoveDocument = require('../epp-common/behaviours/remove-document');
 const ValidateLicenceNumber = require('../epp-common/behaviours/licence-validator');
 
 const UploadFileCounter = require('../epp-common/behaviours/uploaded-files-counter');
+const JourneyValidator = require('../epp-common/behaviours/journey-validator');
 
 // TODO: Use DeleteRedundantDocuments behaviour similar to amend flow to
 // remove the uploaded files when dependent option changes
@@ -15,6 +16,7 @@ module.exports = {
   views: 'apps/epp-replace/views',
   translations: 'apps/epp-replace/translations',
   baseUrl: '/replace',
+  behaviours: [JourneyValidator],
   steps: {
     '/replace-licence': {
       behaviours: [validateAndRedirect, RemoveEditMode],

--- a/test/unit/behaviours/check-back-link.spec.js
+++ b/test/unit/behaviours/check-back-link.spec.js
@@ -25,19 +25,19 @@ describe('check-back-link behaviour tests', () => {
     controller
       .locals(req, res)
       .should.have.property('backLink')
-      .that.equals('/new-and-renew/licence-number');
+      .that.equals('/new-renew/licence-number');
   });
 
   it('renew edit journey - should update backLink to licence-number/edit page', () => {
     req.form.options.route = '/your-name';
-    res.locals.backLink = '/new-and-renew/licence-number/edit';
+    res.locals.backLink = '/new-renew/licence-number/edit';
 
     req.sessionModel.set('isRenewJourney', true);
     controller.locals(req, res).should.have.property('backLink');
     controller
       .locals(req, res)
       .should.have.property('backLink')
-      .that.equals('/new-and-renew/licence-number/edit');
+      .that.equals('/new-renew/licence-number/edit');
   });
 
   it('edit non renew journey - should not update the backLink', () => {

--- a/test/unit/behaviours/get-payment-info.spec.js
+++ b/test/unit/behaviours/get-payment-info.spec.js
@@ -48,11 +48,11 @@ describe('get-payment-info tests', () => {
     req.sessionModel.get.withArgs('applicationType').returns('new');
 
     await behaviour.getValues(req, res, next);
-    expect(res.redirect.calledWith('/new-and-renew/payment-problem')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-problem')).to.be
       .true;
-    expect(res.redirect.calledWith('/new-and-renew/payment-failed')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-failed')).to.be
       .false;
-    expect(res.redirect.calledWith('/new-and-renew/payment-cancelled')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-cancelled')).to.be
       .false;
     expect(next.called).to.be.false;
   });
@@ -66,11 +66,11 @@ describe('get-payment-info tests', () => {
     generateHmacMock.returns('XYZ1234');
 
     await behaviour.getValues(req, res, next);
-    expect(res.redirect.calledWith('/new-and-renew/payment-problem')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-problem')).to.be
       .true;
-    expect(res.redirect.calledWith('/new-and-renew/payment-failed')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-failed')).to.be
       .false;
-    expect(res.redirect.calledWith('/new-and-renew/payment-cancelled')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-cancelled')).to.be
       .false;
     expect(next.called).to.be.false;
   });
@@ -87,11 +87,11 @@ describe('get-payment-info tests', () => {
     });
 
     await behaviour.getValues(req, res, next);
-    expect(res.redirect.calledWith('/new-and-renew/payment-cancelled')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-cancelled')).to.be
       .true;
-    expect(res.redirect.calledWith('/new-and-renew/payment-problem')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-problem')).to.be
       .false;
-    expect(res.redirect.calledWith('/new-and-renew/payment-failed')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-failed')).to.be
       .false;
     expect(next.called).to.be.false;
   });
@@ -108,10 +108,10 @@ describe('get-payment-info tests', () => {
     });
 
     await behaviour.getValues(req, res, next);
-    expect(res.redirect.calledWith('/new-and-renew/payment-failed')).to.be.true;
-    expect(res.redirect.calledWith('/new-and-renew/payment-cancelled')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-failed')).to.be.true;
+    expect(res.redirect.calledWith('/new-renew/payment-cancelled')).to.be
       .false;
-    expect(res.redirect.calledWith('/new-and-renew/payment-problem')).to.be;
+    expect(res.redirect.calledWith('/new-renew/payment-problem')).to.be;
     expect(next.called).to.be.false;
   });
 
@@ -127,11 +127,11 @@ describe('get-payment-info tests', () => {
     });
 
     await behaviour.getValues(req, res, next);
-    expect(res.redirect.calledWith('/new-and-renew/payment-problem')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-problem')).to.be
       .true;
-    expect(res.redirect.calledWith('/new-and-renew/payment-failed')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-failed')).to.be
       .false;
-    expect(res.redirect.calledWith('/new-and-renew/payment-cancelled')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-cancelled')).to.be
       .false;
     expect(next.called).to.be.false;
   });
@@ -148,11 +148,11 @@ describe('get-payment-info tests', () => {
     );
 
     await behaviour.getValues(req, res, next);
-    expect(res.redirect.calledWith('/new-and-renew/payment-problem')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-problem')).to.be
       .true;
-    expect(res.redirect.calledWith('/new-and-renew/payment-failed')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-failed')).to.be
       .false;
-    expect(res.redirect.calledWith('/new-and-renew/payment-cancelled')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-cancelled')).to.be
       .false;
     expect(next.called).to.be.false;
   });
@@ -170,11 +170,11 @@ describe('get-payment-info tests', () => {
 
     await behaviour.getValues(req, res, next);
     expect(next.called).to.be.true;
-    expect(res.redirect.calledWith('/new-and-renew/payment-problem')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-problem')).to.be
       .false;
-    expect(res.redirect.calledWith('/new-and-renew/payment-failed')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-failed')).to.be
       .false;
-    expect(res.redirect.calledWith('/new-and-renew/payment-cancelled')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-cancelled')).to.be
       .false;
   });
 });

--- a/test/unit/behaviours/initiate-payment-request.spec.js
+++ b/test/unit/behaviours/initiate-payment-request.spec.js
@@ -73,7 +73,7 @@ describe('get-payment-info tests', () => {
 
     await behaviour.saveValues(req, res, next);
 
-    expect(res.redirect.calledWith('/new-and-renew/payment-problem')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-problem')).to.be
       .true;
   });
 
@@ -87,7 +87,7 @@ describe('get-payment-info tests', () => {
 
     await behaviour.saveValues(req, res, next);
 
-    expect(res.redirect.calledWith('/new-and-renew/payment-problem')).to.be
+    expect(res.redirect.calledWith('/new-renew/payment-problem')).to.be
       .true;
   });
 

--- a/test/unit/utilities/api.spec.js
+++ b/test/unit/utilities/api.spec.js
@@ -11,7 +11,7 @@ describe('apis.js tests', () => {
     amount: 3950,
     reference: 'New payment Reference',
     description: 'New payment description',
-    return_url: 'http://localhost:8080/new-and-renew/application-submitted',
+    return_url: 'http://localhost:8080/new-renew/application-submitted',
     token: 'ABCD1234',
     metadata: {
       custom_metadata_key1: 'custom_metadata_value1',
@@ -167,11 +167,11 @@ describe('apis.js tests', () => {
     });
 
     it('supported applicationType - should return the path for new flow', () => {
-      expect(getErrorTemplateBasePath('new')).to.equal('/new-and-renew');
+      expect(getErrorTemplateBasePath('new')).to.equal('/new-renew');
     });
 
     it('supported applicationType - should return the path for renew flow', () => {
-      expect(getErrorTemplateBasePath('renew')).to.equal('/new-and-renew');
+      expect(getErrorTemplateBasePath('renew')).to.equal('/new-renew');
     });
 
     it('supported applicationType - should return the path for replace flow', () => {

--- a/test/unit/utilities/utilities.spec.js
+++ b/test/unit/utilities/utilities.spec.js
@@ -189,7 +189,7 @@ describe('EPP utilities tests', () => {
   it('.isEditMode - should return true when in edit mode', () => {
     const urls = [
       'http://localhost:8080/amend/date-of-birth/edit#amend-date-of-birth',
-      'http://localhost:8080/new-and-renew/date-of-birth/edit#amend-date-of-birth',
+      'http://localhost:8080/new-renew/date-of-birth/edit#amend-date-of-birth',
       'https:/domain/replace/date-of-birth/edit#amend-date-of-birth',
       'protocol:/domain/url/edit'
     ];
@@ -204,7 +204,7 @@ describe('EPP utilities tests', () => {
   it('.isEditMode - should return false when not in edit mode', () => {
     const urls = [
       'http://localhost:8080/amend/date-of-birth',
-      'http://localhost:8080/new-and-renew/edit-address#amend-date-of-birth',
+      'http://localhost:8080/new-renew/edit-address#amend-date-of-birth',
       'https:/domain/replace/date-of-birth/edit-first-name#amend-date-of-birth',
       'protocol:/domain/url/test'
     ];

--- a/utilities/constants/string-constants.js
+++ b/utilities/constants/string-constants.js
@@ -1,5 +1,4 @@
 const PATH_NEW_RENEW = '/new-renew';
-const PATH_NEW_AND_RENEW = '/new-and-renew';
 const PATH_AMEND = '/amend';
 const PATH_REPLACE = '/replace';
 const PATH_PAYMENT_PROBLEM = '/payment-problem';
@@ -25,7 +24,6 @@ const API_METHODS = {
 
 module.exports = {
   PATH_NEW_RENEW,
-  PATH_NEW_AND_RENEW,
   PATH_AMEND,
   PATH_REPLACE,
   PATH_PAYMENT_PROBLEM,

--- a/utilities/helpers/api.js
+++ b/utilities/helpers/api.js
@@ -8,10 +8,10 @@ const {
   APP_TYPE_NEW,
   APP_TYPE_RENEW,
   APP_TYPE_REPLACE,
-  PATH_NEW_AND_RENEW,
   PATH_REPLACE,
   API_METHODS,
-  PATH_APPLICATION_SUBMITTED
+  PATH_APPLICATION_SUBMITTED,
+  PATH_NEW_RENEW
 } = require('../constants/string-constants');
 
 /**
@@ -132,7 +132,7 @@ async function getPaymentDetails(paymentId) {
 
 const generateRequestPayload = (req, applicationType, hmac) => {
   const return_url = `${req.protocol}://${req.get('host')}${
-    applicationType === APP_TYPE_REPLACE ? PATH_REPLACE : PATH_NEW_AND_RENEW
+    applicationType === APP_TYPE_REPLACE ? PATH_REPLACE : PATH_NEW_RENEW
   }${PATH_APPLICATION_SUBMITTED}`;
 
   if (applicationType === APP_TYPE_NEW || applicationType === APP_TYPE_RENEW) {
@@ -196,7 +196,7 @@ const generateRequestPayload = (req, applicationType, hmac) => {
 
 const getErrorTemplateBasePath = applicationType => {
   if (applicationType === APP_TYPE_NEW || applicationType === APP_TYPE_RENEW) {
-    return PATH_NEW_AND_RENEW;
+    return PATH_NEW_RENEW;
   }
 
   if (applicationType === APP_TYPE_REPLACE) {


### PR DESCRIPTION
## What?
- Update base url for new and renew forms from `/new-and-renew` to `/new-renew `
- Added Journey Validator to protect routes
## Why? 
Business/UCD suggested to update the base path /new-renew as its clear and concise 
## How? 
Path is changed across the application
## Testing?
tested locally
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
