### PR TITLE
EPP-212 replace upload Birth Certificate

### DIFF
--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -4,7 +4,6 @@ const RemoveEditMode = require('../epp-common/behaviours/remove-edit-mode');
 const SaveDocument = require('../epp-common/behaviours/save-document');
 const RemoveDocument = require('../epp-common/behaviours/remove-document');
 const ValidateLicenceNumber = require('../epp-common/behaviours/licence-validator');
-
 const UploadFileCounter = require('../epp-common/behaviours/uploaded-files-counter');
 const JourneyValidator = require('../epp-common/behaviours/journey-validator');
 
@@ -222,6 +221,15 @@ module.exports = {
     },
     '/section-twenty-one': {
       fields: ['replace-countersignatory-document-type'],
+      next: '/birth-certificate'
+    },
+    '/birth-certificate': {
+      behaviours: [
+        SaveDocument('replace-birth-certificate', 'file-upload'),
+        RemoveDocument('replace-birth-certificate')
+      ],
+      fields: ['file-upload'],
+      locals: { captionHeading: 'Section 24 of 26' },
       next: '/confirm'
     },
     '/confirm': {

--- a/apps/epp-replace/sections/summary-data-sections.js
+++ b/apps/epp-replace/sections/summary-data-sections.js
@@ -1,5 +1,7 @@
 'use strict';
-
+const {
+  isDateOlderOrEqualTo
+} = require('../../../utilities/helpers');
 module.exports = {
   'replace-licence': {
     steps: [
@@ -114,6 +116,24 @@ module.exports = {
       {
         step: '/licence-number',
         field: 'replace-licence-number'
+      }
+    ]
+  },
+  'countersignatory-details': {
+    steps: [
+      {
+        step: '/birth-certificate',
+        field: 'replace-birth-certificate',
+        parse: (documents, req) => {
+          if (
+            req.sessionModel.get('steps').includes('/birth-certificate') &&
+            documents?.length > 0 && req.sessionModel.get('replace-date-of-birth')
+            && !isDateOlderOrEqualTo(req.sessionModel.get('replace-date-of-birth'), 18)
+          ) {
+            return documents.map(file => file?.name)?.join('\n\n');
+          }
+          return null;
+        }
       }
     ]
   }

--- a/apps/epp-replace/translations/src/en/pages.json
+++ b/apps/epp-replace/translations/src/en/pages.json
@@ -1,18 +1,18 @@
 {
-    "application-submitted": {
-        "confirmed": "Replaced application submitted"
-      },
-      "upload-british-passport" : {
-        "header": "Upload British passport",
-        "label": "Upload a file",
-        "hint": "Your file must be JPEG, PDF or PNG and be 25MB or less",
-        "paragraph1": "Attach an image of your British passport as proof of your identity. the image must be",
-        "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
-        "link-text" : "signed by your countersignatory (opens in a new tab).",
-        "uploading-document": "Uploading your document..",
-        "not-uploaded": "No files uploaded",
-        "uploaded": "Files uploaded"
-      },
+  "application-submitted": {
+    "confirmed": "Replaced application submitted"
+  },
+  "upload-british-passport": {
+    "header": "Upload British passport",
+    "label": "Upload a file",
+    "hint": "Your file must be JPEG, PDF or PNG and be 25MB or less",
+    "paragraph1": "Attach an image of your British passport as proof of your identity. the image must be",
+    "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
+    "link-text": "signed by your countersignatory (opens in a new tab).",
+    "uploading-document": "Uploading your document..",
+    "not-uploaded": "No files uploaded",
+    "uploaded": "Files uploaded"
+  },
   "upload-passport": {
     "header": "Upload passport",
     "p1": "Attach an image of your passport from the EU, Switzerland, Norway, Iceland or Liechtenstein as proof of your identity. The image must be",
@@ -64,53 +64,66 @@
     "paragraph1": "A certificate of good conduct is issued by the police in your country of nationality. It shows if you have a criminal record and details of any offences.",
     "paragraph2": "Attach an image of your certificate of good conduct. The image must be ",
     "link": "https://www.gov.uk/government/publications/explosives-precursors-licence-applications-countersignatory/explosives-precursors-and-poisons-licence-applications-how-to-get-documents-countersigned",
-    "link-text" : "signed by your countersignatory (opens in a new tab).",
+    "link-text": "signed by your countersignatory (opens in a new tab).",
     "uploading-document": "Uploading your document..",
     "not-uploaded": "No files uploaded",
     "uploaded": "Files uploaded"
   },
+  "birth-certificate": {
+    "header": "Your countersignatory must be your parent or guardian",
+    "p1": "You told us you are under 18. Your countersignatory must be your parent or legal guardian.",
+    "p2": "To prove this relationship, upload a countersigned copy of your birth certificate or other legal document.",
+    "upload-file": "Upload a file",
+    "file-format": "Your file must be JPEG, PDF or PNG, and be 25MB or less",
+    "no-file-uploaded": "No files uploaded",
+    "files-uploaded": "Files uploaded",
+    "uploading-document": "Uploading your document..."
+  },
   "your-name": {
     "header": "What is your name on the licence?"
   },
-      "confirm": {
-        "header": "Check your answers",
-        "subheader": "Review your answers below and amend if required before proceeding to declaration and payment.",
-        "sections": {
-          "countersignatory-details": {
-            "header": "Countersignatory details"
-          },
-          "licence-details": {
-            "header": "Licence details"
-          },
-          "replace-licence": {
-            "header": "Replacement reason"
-          },
-          "replace-new-name": {
-            "header": "New name"
-          },
-          "applicant-name": {
-            "header": "Applicant name"
-          }
-        },
-      "fields": {
-        "replace-licence-number": {
-          "label": "Licence number"
-        },
-        "replace-british-passport" : {
-          "label": "British passport attachment"
-        },
-        "replace-eu-passport" : {
-          "label": "Passport attachment"
-        },
-        "replace-upload-driving-licence": {
-          "label": "UK driving licence attachment"
-        },
-        "replace-proof-address": {
-          "label": "Proof of address attachments"
-        },
-        "replace-certificate-conduct" :{
-          "label": "Certificate of good conduct attachment"
-        }
+  "confirm": {
+    "header": "Check your answers",
+    "subheader": "Review your answers below and amend if required before proceeding to declaration and payment.",
+    "sections": {
+      "countersignatory-details": {
+        "header": "Countersignatory details"
+      },
+      "licence-details": {
+        "header": "Licence details"
+      },
+      "replace-licence": {
+        "header": "Replacement reason"
+      },
+      "replace-new-name": {
+        "header": "New name"
+      },
+      "applicant-name": {
+        "header": "Applicant name"
+      }
+    },
+    "fields": {
+      "replace-licence-number": {
+        "label": "Licence number"
+      },
+      "replace-british-passport": {
+        "label": "British passport attachment"
+      },
+      "replace-eu-passport": {
+        "label": "Passport attachment"
+      },
+      "replace-upload-driving-licence": {
+        "label": "UK driving licence attachment"
+      },
+      "replace-proof-address": {
+        "label": "Proof of address attachments"
+      },
+      "replace-certificate-conduct": {
+        "label": "Certificate of good conduct attachment"
+      },
+      "replace-birth-certificate": {
+        "label": "Birth certificate attachment"
       }
     }
+  }
 }

--- a/apps/epp-replace/translations/src/en/validation.json
+++ b/apps/epp-replace/translations/src/en/validation.json
@@ -8,7 +8,8 @@
     "maxReplaceEuPassport": "You can only upload up to {{maxReplaceEuPassport}} files or less. Remove a file before uploading another",
     "maxReplaceDrivingLicence": "You can only upload up to {{maxReplaceDrivingLicence}} files or less. Remove a file before uploading another",
     "maxReplaceProofAddress" : "You can only upload up to {{maxReplaceProofAddress}} files or less. Remove a file before uploading another",
-    "maxReplaceCertificateConduct" : "You can only upload up to {{maxReplaceCertificateConduct}} files or less. Remove a file before uploading another"
+    "maxReplaceCertificateConduct" : "You can only upload up to {{maxReplaceCertificateConduct}} files or less. Remove a file before uploading another",
+    "maxReplaceBirthCertificate": "You can only upload upto {{maxReplaceBirthCertificate}} files or less. Remove a file before uploading another"
   },
   "replace-licence-number": {
     "incorrect-format-licence": "Enter a real licence number",

--- a/apps/epp-replace/views/birth-certificate.html
+++ b/apps/epp-replace/views/birth-certificate.html
@@ -1,0 +1,56 @@
+{{<partials-page}} {{$encoding}}enctype="multipart/form-data" name="file-upload-form" {{/encoding}} 
+{{$page-content}}
+<p class="govuk-body">{{#t}}pages.birth-certificate.p1{{/t}}</p>
+
+<p class="govuk-body">{{#t}}pages.birth-certificate.p2{{/t}}</p>
+
+<div class="govuk-form-group" id="hofFileUpload">
+    <label class="govuk-label" for="file-upload">
+        <h2>{{#t}}pages.birth-certificate.upload-file{{/t}}</h2>
+        <span class="govuk-hint">{{#t}}pages.birth-certificate.file-format{{/t}}</span>
+    </label>
+    <p id="file-upload-error-maxFileSize" class="govuk-error-message govuk-!-display-none">
+        <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.maxFileSize{{/t}}
+    </p>
+    <p id="file-upload-error-fileType" class="govuk-error-message govuk-!-display-none">
+        <span id="validation-error" class="govuk-visually-hidden">{{#t}}journey.error{{/t}}:</span> {{#t}}validation.file-upload.fileType{{/t}}
+    </p>
+    <input class="govuk-file-upload" id="file-upload" name="file-upload" type="file" value="replace-birth-certificate">
+
+    <div id="upload-page-loading-spinner" class="spinner-container">
+        <div class="spinner-loader"></div>
+        <span class="spinner-message">{{#t}}pages.birth-certificate.uploading-document{{/t}}</span>
+      </div>
+
+</div>
+
+{{^values.replace-birth-certificate}}
+<h2 class="govuk-heading-m">{{#t}}pages.birth-certificate.no-file-uploaded{{/t}}</h2>
+{{/values.replace-birth-certificate}}
+
+{{#values.replace-birth-certificate.length}}
+<h2 class="govuk-heading-m">{{#t}}pages.birth-certificate.files-uploaded{{/t}}</h2>
+
+<div id="uploaded-documents" class="govuk-width-container">
+    {{#values.replace-birth-certificate}}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-three-quarters">
+            {{name}}
+        </div>
+        <div class="govuk-grid-column-one-quarter">
+            <a href="?delete={{id}}" class="govuk-link">{{#t}}buttons.remove{{/t}}<span class="visuallyhidden">{{name}}</span></a>
+        </div>
+    </div>
+    <div class="file-upload-hrline"></div>
+    {{/values.replace-birth-certificate}}
+</div>
+
+{{/values.replace-birth-certificate.length}}
+
+
+<button class="govuk-button" name="requireFileUpload" value="replace-birth-certificate">
+    {{#t}}buttons.continue{{/t}}
+</button>
+
+{{/page-content}}
+{{/partials-page}}

--- a/config.js
+++ b/config.js
@@ -147,6 +147,11 @@ module.exports = {
         allowMultipleUploads: false,
         limit: 1,
         limitValidationError: 'maxReplaceCertificateConduct'
+      },
+      'replace-birth-certificate': {
+        allowMultipleUploads: false,
+        limit: 1,
+        limitValidationError: 'maxReplaceBirthCertificate'
       }
     }
   },


### PR DESCRIPTION
## What? 
create upload birth certificate for replace journey as per jira ticket [EPP-212](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-212)
## Why? 
to give  the user the opportunity to upload a birth certificate file
## How? 
- add birth-certificate.html upload page
- update page.json, validation.json, index.js and summary-data-sections.js
## Testing?
manual test
## Screenshots (optional)
currently this element is not visible in the confirmation summary page, since the conditional statement used to retrieve and display the value will be always false since date or birth page is not child  yet.
![image](https://github.com/user-attachments/assets/df27d5d0-7672-4f77-8ad0-4e9d0c1a17c9)

## Anything Else? (optional)
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
