### PR TITLE
EPP-210 replace countersignatory ID

### DIFF
--- a/apps/epp-replace/fields/index.js
+++ b/apps/epp-replace/fields/index.js
@@ -1,5 +1,6 @@
 const titles = require('../../../utilities/constants/titles');
-const poisonsList = require('../../../utilities/constants/poisons.js');const helpers = require('../../../utilities/helpers/index.js');
+const poisonsList = require('../../../utilities/constants/poisons.js');
+const helpers = require('../../../utilities/helpers/index.js');
 
 module.exports = {
   'replace-licence-number': {

--- a/apps/epp-replace/fields/index.js
+++ b/apps/epp-replace/fields/index.js
@@ -1,5 +1,6 @@
 const titles = require('../../../utilities/constants/titles');
-const poisonsList = require('../../../utilities/constants/poisons.js');
+const poisonsList = require('../../../utilities/constants/poisons.js');const helpers = require('../../../utilities/helpers/index.js');
+
 module.exports = {
   'replace-licence-number': {
     mixin: 'input-text',
@@ -51,5 +52,66 @@ module.exports = {
         label: 'fields.replace-poison.options.none_selected'
       }
     ].concat(poisonsList)
+  },
+  'replace-countersignatory-Id-type': {
+    isPageHeading: true,
+    mixin: 'radio-group',
+    validate: ['required'],
+    options: [
+      {
+        value: 'UK-passport',
+        toggle: 'replace-countersignatory-UK-passport-number',
+        child: 'input-text'
+      },
+      {
+        value: 'EU-passport',
+        toggle: 'replace-countersignatory-EU-passport-number',
+        child: 'input-text'
+      },
+      {
+        value: 'Uk-driving-licence',
+        toggle: 'replace-countersignatory-Uk-driving-licence-number',
+        child: 'input-text'
+      }
+    ]
+  },
+  'replace-countersignatory-UK-passport-number': {
+    validate: [
+      'required',
+      { type: 'maxlength', arguments: 9 },
+      'alphanum',
+      'notUrl'
+    ],
+    className: ['govuk-input', 'govuk-!-width-one-thirds'],
+    dependent: {
+      field: 'replace-countersignatory-Id-type',
+      value: 'UK-passport'
+    }
+  },
+  'replace-countersignatory-EU-passport-number': {
+    validate: [
+      'required',
+      { type: 'maxlength', arguments: 9 },
+      'alphanum',
+      'notUrl'
+    ],
+    className: ['govuk-input', 'govuk-!-width-one-thirds'],
+    dependent: {
+      field: 'replace-countersignatory-Id-type',
+      value: 'EU-passport'
+    }
+  },
+  'replace-countersignatory-Uk-driving-licence-number': {
+    validate: [
+      'required',
+      'notUrl',
+      { type: 'minlength', arguments: 16 },
+      helpers.isValidUkDrivingLicenceNumber
+    ],
+    className: ['govuk-input', 'govuk-!-width-one-thirds'],
+    dependent: {
+      field: 'replace-countersignatory-Id-type',
+      value: 'Uk-driving-licence'
+    }
   }
 };

--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -227,7 +227,7 @@ module.exports = {
     },
     '/section-twenty-one': {
       fields: ['replace-countersignatory-document-type'],
-      next: '/birth-certificate'
+      next: '/countersignatory-id'
     },
     '/countersignatory-id': {
       behaviours: [DobUnder18Redirect('replace-date-of-birth', '/birth-certificate')],

--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -6,6 +6,7 @@ const RemoveDocument = require('../epp-common/behaviours/remove-document');
 const ValidateLicenceNumber = require('../epp-common/behaviours/licence-validator');
 const UploadFileCounter = require('../epp-common/behaviours/uploaded-files-counter');
 const JourneyValidator = require('../epp-common/behaviours/journey-validator');
+const DobUnder18Redirect = require('../epp-common/behaviours/dob-under18-redirect');
 
 // TODO: Use DeleteRedundantDocuments behaviour similar to amend flow to
 // remove the uploaded files when dependent option changes
@@ -227,6 +228,17 @@ module.exports = {
     '/section-twenty-one': {
       fields: ['replace-countersignatory-document-type'],
       next: '/birth-certificate'
+    },
+    '/countersignatory-id': {
+      behaviours: [DobUnder18Redirect('replace-date-of-birth', '/birth-certificate')],
+      fields: [
+        'replace-countersignatory-Id-type',
+        'replace-countersignatory-UK-passport-number',
+        'replace-countersignatory-EU-passport-number',
+        'replace-countersignatory-Uk-driving-licence-number'
+      ],
+      locals: { captionHeading: 'Section 24 of 26' },
+      next: '/confirm'
     },
     '/birth-certificate': {
       behaviours: [

--- a/apps/epp-replace/sections/summary-data-sections.js
+++ b/apps/epp-replace/sections/summary-data-sections.js
@@ -131,19 +131,19 @@ module.exports = {
     steps: [
       {
         step: '/countersignatory-id',
-        field: 'require-countersignatory-Id-type'
+        field: 'replace-countersignatory-Id-type'
       },
       {
         step: '/countersignatory-id',
-        field: 'require-countersignatory-UK-passport-number'
+        field: 'replace-countersignatory-UK-passport-number'
       },
       {
         step: '/countersignatory-id',
-        field: 'require-countersignatory-EU-passport-number'
+        field: 'replace-countersignatory-EU-passport-number'
       },
       {
         step: '/countersignatory-id',
-        field: 'require-countersignatory-Uk-driving-licence-number'
+        field: 'replace-countersignatory-Uk-driving-licence-number'
       },
       {
         step: '/birth-certificate',

--- a/apps/epp-replace/sections/summary-data-sections.js
+++ b/apps/epp-replace/sections/summary-data-sections.js
@@ -130,6 +130,22 @@ module.exports = {
   'countersignatory-details': {
     steps: [
       {
+        step: '/countersignatory-id',
+        field: 'require-countersignatory-Id-type'
+      },
+      {
+        step: '/countersignatory-id',
+        field: 'require-countersignatory-UK-passport-number'
+      },
+      {
+        step: '/countersignatory-id',
+        field: 'require-countersignatory-EU-passport-number'
+      },
+      {
+        step: '/countersignatory-id',
+        field: 'require-countersignatory-Uk-driving-licence-number'
+      },
+      {
         step: '/birth-certificate',
         field: 'replace-birth-certificate',
         parse: (documents, req) => {

--- a/apps/epp-replace/translations/src/en/fields.json
+++ b/apps/epp-replace/translations/src/en/fields.json
@@ -40,5 +40,33 @@
           "options":{
             "none_selected": "Select poison"
         }
+      },
+      "replace-countersignatory-Id-type": {
+        "legend": "Which identity document do you want to use?",
+        "hint": "If your licence is granted, you will need to show this document when buying the substances",
+        "options": {
+          "UK-passport": {
+            "label": "British passport"
+          },
+          "EU-passport": {
+            "label": "Passport from the EU, Switzerland, Norway, Iceland or Liechtenstein"
+          },
+          "Uk-driving-licence": {
+            "label": "UK driving licence",
+            "hint": "Must be a photocard licence."
+          }
+        }
+      },
+      "replace-countersignatory-UK-passport-number": {
+        "label": "What is your passport number?",
+        "hint" : "For example, 120897A"    
+      },
+      "replace-countersignatory-EU-passport-number": {
+        "label": "What is your passport number?",
+        "hint" : "For example, 120897A"  
+      },
+      "replace-countersignatory-Uk-driving-licence-number": {
+        "label": "What is your driving licence number?",
+        "hint" : "On section 5 of your licence, for example MORGA657054SM9IJ"    
       }
 }

--- a/apps/epp-replace/translations/src/en/pages.json
+++ b/apps/epp-replace/translations/src/en/pages.json
@@ -137,6 +137,18 @@
       },
       "replace-poison": {
         "label": "Poisons"
+      },
+      "replace-countersignatory-Id-type": {
+        "label": "Identification document"
+      },
+      "replace-countersignatory-UK-passport-number": {
+        "label": "British passport number"
+      },
+      "replace-countersignatory-EU-passport-number": {
+        "label": "Passport number"
+      },
+      "replace-countersignatory-Uk-driving-licence-number": {
+        "label": "UK driving licence number"
       }
     }
   }

--- a/apps/epp-replace/translations/src/en/validation.json
+++ b/apps/epp-replace/translations/src/en/validation.json
@@ -37,5 +37,27 @@
   },
   "replace-poison": {
     "required": "Select a poison"
-  }
+  },
+"replace-countersignatory-Id-type": {
+  "required": "Select which identity document you want to use"
+},
+"replace-countersignatory-UK-passport-number": {
+  "required": "Enter your passport number",
+  "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer",
+  "maxlength": "Passport number must be 9 characters or less",
+  "alphanum": "Passport number must only include numbers and letters a-z"
+  
+},
+"replace-countersignatory-EU-passport-number": {
+  "required": "Enter your passport number",
+  "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer", 
+  "maxlength": "Passport number must be 9 characters or less",
+  "alphanum": " Passport number must only include numbers and letters a-z"
+},
+"replace-countersignatory-Uk-driving-licence-number": {
+  "required": "Enter your driving licence number",
+  "isValidUkDrivingLicenceNumber": "Enter a real UK driving licence number",
+  "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer",
+  "minlength": "Driving licence number must be 16 characters"
+}
 }


### PR DESCRIPTION
## What? 
create a Countersignatory ID type and number page as per jira ticket [EPP-210](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-210)
## Why? 
to give user opportunity to select preferred document type and provide its number
## How? 
- add new fields in fields/index.js, , fields.json, pages.json, validation.json 
- update index.js
- update summary-data-sections.js
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
