### PR TITLE
EPP-42 Previous address history summary page

### DIFF
--- a/apps/epp-common/behaviours/parse-summary-fields.js
+++ b/apps/epp-common/behaviours/parse-summary-fields.js
@@ -17,7 +17,8 @@ module.exports = superclass =>
       // Update dateFields with every new date field that needs to be formatted
       const dateFields = [
         'new-renew-other-name-start-date',
-        'new-renew-other-name-stop-date'
+        'new-renew-other-name-stop-date',
+        'new-renew-previous-home-address-moveto-date'
       ];
       const locals = super.locals(req, res);
       locals.items = locals.items.map(item => {

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -201,7 +201,21 @@ module.exports = {
       }
     },
     '/previous-addresses': {
-      fields: [],
+      behaviours: [AggregateSaveUpdate, ParseSummaryFields, EditRouteReturn],
+      aggregateTo: 'otheraddresses',
+      aggregateFrom: [
+        'new-renew-previous-home-address-line1',
+        'new-renew-previous-home-address-line2',
+        'new-renew-previous-home-address-town',
+        'new-renew-previous-home-address-county',
+        'new-renew-previous-home-address-postcode',
+        'new-renew-previous-home-address-country',
+        'new-renew-previous-home-address-moveto-date'
+      ],
+      titleField: 'new-renew-previous-home-address-line1',
+      addStep: 'previous-address',
+      addAnotherLinkText: 'previous address',
+      continueOnEdit: false,
       next: '/upload-proof-address',
       locals: {
         sectionNo: {

--- a/apps/epp-new/sections/summary-data-sections.js
+++ b/apps/epp-new/sections/summary-data-sections.js
@@ -144,7 +144,7 @@ module.exports = {
       {
         step: '/previous-addresses',
         field: 'otheraddresses',
-        changeLink: '/new-and-renew/previous-addresses',
+        changeLink: '/new-renew/previous-addresses',
         parse: (list, req) => {
           if (req.sessionModel.get('new-renew-previous-addresses') === 'no') {
             return null;

--- a/apps/epp-new/sections/summary-data-sections.js
+++ b/apps/epp-new/sections/summary-data-sections.js
@@ -142,6 +142,25 @@ module.exports = {
         parse: date => date && dateFormatter.format(new Date(date))
       },
       {
+        step: '/previous-addresses',
+        field: 'otheraddresses',
+        changeLink: '/new-and-renew/previous-addresses',
+        parse: (list, req) => {
+          if (req.sessionModel.get('new-renew-previous-addresses') === 'no') {
+            return null;
+          }
+          return req.sessionModel.get('otheraddresses')?.aggregatedValues.length > 0 ?
+            req.sessionModel.get('otheraddresses').aggregatedValues.map(a => a.fields.map(field => {
+              if (
+                field.field === 'new-renew-previous-home-address-moveto-date'
+              ) {
+                field.parsed = getFormattedDate(field.parsed);
+              }
+              return field.parsed;
+            }).filter(Boolean).join('\n')).join('\n \n') : null;
+        }
+      },
+      {
         step: '/upload-proof-address',
         field: 'new-renew-proof-address',
         parse: (documents, req) => {

--- a/apps/epp-new/translations/src/en/fields.json
+++ b/apps/epp-new/translations/src/en/fields.json
@@ -259,31 +259,38 @@
     "hint": "For example, 30 10 2014"
   },
   "new-renew-previous-home-address-line1": {
-    "label": "Address line 1"
+    "label": "Address line 1",
+    "summary-heading": "Address line 1"
   },
   "new-renew-previous-home-address-line2": {
-    "label": "Address line 2 (optional)"
+    "label": "Address line 2 (optional)",
+    "summary-heading": "Address line 2 (optional)"
   },
   "new-renew-previous-home-address-town": {
-    "label": "Town or city"
+    "label": "Town or city",
+    "summary-heading": "Town or city"
   },
   "new-renew-previous-home-address-county": {
-    "label": "County, state, province (optional)"
+    "label": "County, state, province (optional)",
+    "summary-heading": "County, state, province (optional)"
   },
   "new-renew-previous-home-address-postcode": {
     "label": "Postcode (optional)",
-    "hint": "Postcode is optional if your address is outside the UK"
+    "hint": "Postcode is optional if your address is outside the UK",
+    "summary-heading": "Postcode (optional)"
   },
   "new-renew-previous-home-address-country": {
     "label": "Country of address",
     "hint": "Select a country from the list",
     "options": {
       "none_selected": "Select"
-    }
+    },
+    "summary-heading": "Country of address"
   },
   "new-renew-previous-home-address-moveto-date": {
     "legend": "When did you move to this address?",
-    "hint": "For example, 30 10 2014"
+    "hint": "For example, 30 10 2014",
+    "summary-heading": "When did you move to this address?"
   },
   "new-renew-countersignatory-title":{
     "label": "Title",

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -19,6 +19,9 @@
     "title": "Other names summary",
     "header": "Other nationalities"
   },
+  "previous-addresses": {
+    "header": "Previous address history"
+  },
   "home-address": {
     "header": "What is your home address?"
   },
@@ -243,11 +246,17 @@
       },
       "other-names-summary": {
         "header": "Other names summary"
+      },
+      "previous-addresses": {
+        "label": "Previous addresses"
       }
     },
     "fields": {
       "new-renew-licence-number": {
         "label": "Licence number"
+      },
+      "otheraddresses": {
+        "label": "Previous addresses"
       },
       "new-renew-other-country-nationality": {
         "label": "Other nationality"
@@ -302,6 +311,9 @@
       },
       "othernames": {
         "label": "Other names"
+      },
+      "otheraddresses": {
+        "label": "Previous addresses"
       },
       "new-renew-countersignatory-middlename": {
         "label": "Middle names"

--- a/apps/epp-new/views/previous-addresses.html
+++ b/apps/epp-new/views/previous-addresses.html
@@ -1,5 +1,6 @@
 {{<partials-page}}
   {{$page-content}}
+  <p>You must enter your address from the last 5 years. This information helps us carry out the suitability checks needed to issue a licence.</p>
   {{> partials-aggregator-summary-table}}
   <br>
   <a href="{{baseUrl}}/{{addStep}}" class="govuk-button govuk-button--secondary" data-module="govuk-button">
@@ -9,4 +10,3 @@
   {{#input-submit}}continue{{/input-submit}}
   {{/page-content}}
 {{/partials-page}}
-


### PR DESCRIPTION
## What? 
[EPP-42](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-42) - Create Previous address history summary page for New-Renew - EPP

## Why? 
Allows user to view their addresses they have input

## How? 
- Added summary table for previous addresses
- Added validations for page
- Added for summary page section 

## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
