### PR TITLE
EPP-249 Telephone number validation

### DIFF
--- a/apps/epp-amend/fields/index.js
+++ b/apps/epp-amend/fields/index.js
@@ -44,7 +44,7 @@ module.exports = {
     mixin: 'input-text',
     className: ['govuk-input'],
     labelClassName: 'govuk-label--m',
-    validate: ['required', 'internationalPhoneNumber']
+    validate: ['required', 'notUrl', helpers.validInternationalPhoneNumber]
   },
   'amend-email': {
     mixin: 'input-text',

--- a/apps/epp-amend/translations/src/en/validation.json
+++ b/apps/epp-amend/translations/src/en/validation.json
@@ -57,8 +57,9 @@
         "required" : "Select a country of address"
     },
     "amend-phone-number": {
-        "required": "Enter your telephone number",
-        "internationalPhoneNumber": "Enter a real telephone number"
+      "required": "Enter your telephone number",
+      "validInternationalPhoneNumber": "Enter a real telephone number",
+      "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
     },
     "amend-email": {
         "required": "Enter a contact email address",

--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -54,7 +54,7 @@ module.exports = {
   },
   'new-renew-phone-number': {
     mixin: 'input-text',
-    validate: ['required', 'internationalPhoneNumber'],
+    validate: ['required', 'notUrl', validInternationalPhoneNumber],
     className: ['govuk-input'],
     labelClassName: 'govuk-label--m'
   },

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -21,7 +21,8 @@
     },
     "new-renew-phone-number": {
         "required": "Enter your telephone number",
-        "internationalPhoneNumber": "Enter a real telephone number"
+        "validInternationalPhoneNumber": "Enter a real telephone number",
+        "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
     },
     "new-renew-email": {
         "required": "Enter a contact email address",


### PR DESCRIPTION
## What? 
[EPP-249](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-249) - Contact Phone Number Accepts Letters
## Why? 
The phone number field allows letters, but it should only accept numerical values.
## How? 
Validation is updated using the existing custom tel number validator
## Testing?
local and branch testing
## Screenshots (optional)

![Screenshot 2025-03-12 at 10 33 35](https://github.com/user-attachments/assets/531986ac-8fde-4e22-a100-807a0b1ee791)


## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
