### PR TITLE
EPP-217 Have details changed page

### DIFF
--- a/apps/epp-replace/fields/index.js
+++ b/apps/epp-replace/fields/index.js
@@ -183,6 +183,14 @@ module.exports = {
       }
     ]
   },
+  'replace-is-details-changed': {
+    fields: ['replace-is-details-changed'],
+    mixin: 'radio-group',
+    isPageHeading: true,
+    validate: 'required',
+    options: ['yes', 'no'],
+    className: ['govuk-radios', 'govuk-radios--inline']
+  },
   'replace-countersignatory-UK-passport-number': {
     validate: [
       'required',

--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -96,10 +96,27 @@ module.exports = {
     },
     '/section-seven': {
       fields: ['replace-phone-number', 'replace-email'],
-      next: '/section-eight'
+      next: '/changed-details'
     },
-    '/section-eight': {
+    '/changed-details': {
       fields: ['replace-is-details-changed'],
+      forks: [
+        {
+          target: '/section-nine',
+          condition: {
+            field: 'replace-is-details-changed',
+            value: 'yes'
+          }
+        },
+        {
+          target: '/confirm',
+          condition: {
+            field: 'replace-is-details-changed',
+            value: 'no'
+          }
+        }
+      ],
+      locals: { captionHeading: 'Section 2 of 26' },
       next: '/section-nine'
     },
     '/section-nine': {

--- a/apps/epp-replace/sections/summary-data-sections.js
+++ b/apps/epp-replace/sections/summary-data-sections.js
@@ -17,6 +17,14 @@ module.exports = {
       }
     ]
   },
+  'replace-is-details-changed': {
+    steps: [
+      {
+        step: '/changed-details',
+        field: 'replace-is-details-changed'
+      }
+    ]
+  },
   'replace-new-name': {
     steps: [
       {

--- a/apps/epp-replace/translations/src/en/fields.json
+++ b/apps/epp-replace/translations/src/en/fields.json
@@ -46,6 +46,18 @@
           }
         }
       },
+      "replace-is-details-changed": {
+        "legend": "Have any of your details changed since the licence was issued?",
+        "hint": "Includes the name, address and substances recorded on the licence",
+        "options": {
+          "yes": {
+            "label": "Yes"
+          },
+          "no": {
+            "label": "No"
+          }
+        }
+      },
       "replace-countersignatory-title":{
         "label": "Title",
         "options": {

--- a/apps/epp-replace/translations/src/en/pages.json
+++ b/apps/epp-replace/translations/src/en/pages.json
@@ -124,11 +124,17 @@
       },
       "countersignatory-details": {
         "header": "Countersignatory details"
+      },
+      "replace-is-details-changed": {
+        "header": "Changes to licence"
       }
     },
     "fields": {
       "replace-licence-number": {
         "label": "Licence number"
+      },
+      "replace-is-details-changed": {
+        "label": "Have any of your details changed since the licence was issued?"
       },
       "replace-police-report": {
         "label": "Have you reported the theft to the police?"

--- a/apps/epp-replace/translations/src/en/validation.json
+++ b/apps/epp-replace/translations/src/en/validation.json
@@ -122,5 +122,8 @@
 },
 "replace-police-report": {
   "required": "Select if you have reported the theft to the police"
+},
+"replace-is-details-changed": {
+  "required": "Select if any of your details have changed since the licence was issued"
 }
 }


### PR DESCRIPTION
## What? 
[EPP-217](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-217) - Create Have details changed page for Replace - EPP

## Why? 
Allows user to input if their details have changed

## How? 
- Added Heading and radio buttons for page
- Added validations for page

## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging