### PR TITLE
EPP-190 create identity details page

### DIFF
--- a/apps/epp-replace/fields/index.js
+++ b/apps/epp-replace/fields/index.js
@@ -1,9 +1,8 @@
 const titles = require('../../../utilities/constants/titles');
 const poisonsList = require('../../../utilities/constants/poisons.js');
 const countersignatoryYears = require('../../../utilities/constants/countersignatory-years.js');
-const { isValidUkDrivingLicenceNumber } = require('../../../utilities/helpers');
+const { isValidUkDrivingLicenceNumber, validInternationalPhoneNumber } = require('../../../utilities/helpers');
 const helpers = require('../../../utilities/helpers/index.js');
-const { validInternationalPhoneNumber } = require('../../../utilities/helpers');
 
 module.exports = {
   'replace-licence-number': {

--- a/apps/epp-replace/fields/index.js
+++ b/apps/epp-replace/fields/index.js
@@ -1,10 +1,9 @@
 const titles = require('../../../utilities/constants/titles');
 const poisonsList = require('../../../utilities/constants/poisons.js');
 const countersignatoryYears = require('../../../utilities/constants/countersignatory-years.js');
-const { validInternationalPhoneNumber } = require('../../../utilities/helpers');
-const dateComponent = require('hof').components.date;
-
+const { isValidUkDrivingLicenceNumber } = require('../../../utilities/helpers');
 const helpers = require('../../../utilities/helpers/index.js');
+const { validInternationalPhoneNumber } = require('../../../utilities/helpers');
 
 module.exports = {
   'replace-licence-number': {
@@ -218,11 +217,6 @@ module.exports = {
       value: 'EU-passport'
     }
   },
-  'replace-date-of-birth': dateComponent('replace-date-of-birth', {
-    mixin: 'input-date',
-    legend: { className: 'bold' },
-    validate: ['required', 'date', 'before']
-  }),
   'replace-countersignatory-Uk-driving-licence-number': {
     validate: [
       'required',
@@ -233,6 +227,67 @@ module.exports = {
     className: ['govuk-input', 'govuk-!-width-one-thirds'],
     dependent: {
       field: 'replace-countersignatory-Id-type',
+      value: 'Uk-driving-licence'
+    }
+  },
+  'replace-which-document-type': {
+    isPageHeading: true,
+    mixin: 'radio-group',
+    validate: ['required'],
+    options: [
+      {
+        value: 'UK-passport',
+        toggle: 'replace-UK-passport-number',
+        child: 'input-text'
+      },
+      {
+        value: 'EU-passport',
+        toggle: 'replace-EU-passport-number',
+        child: 'input-text'
+      },
+      {
+        value: 'Uk-driving-licence',
+        toggle: 'replace-Uk-driving-licence-number',
+        child: 'input-text'
+      }
+    ]
+  },
+  'replace-UK-passport-number': {
+    validate: [
+      'required',
+      { type: 'maxlength', arguments: 9 },
+      'alphanum',
+      'notUrl'
+    ],
+    className: ['govuk-input', 'govuk-!-width-one-thirds'],
+    dependent: {
+      field: 'replace-which-document-type',
+      value: 'UK-passport'
+    }
+  },
+  'replace-EU-passport-number': {
+    validate: [
+      'required',
+      { type: 'maxlength', arguments: 9 },
+      'alphanum',
+      'notUrl'
+    ],
+    className: ['govuk-input', 'govuk-!-width-one-thirds'],
+    dependent: {
+      field: 'replace-which-document-type',
+      value: 'EU-passport'
+    }
+  },
+  'replace-Uk-driving-licence-number': {
+    validate: [
+      'required',
+      'notUrl',
+      { type: 'minlength', arguments: 16 },
+      isValidUkDrivingLicenceNumber
+    ],
+    className: ['govuk-input', 'govuk-!-width-one-thirds'],
+    dependent: {
+      field: 'replace-which-document-type',
       value: 'Uk-driving-licence'
     }
   }

--- a/apps/epp-replace/fields/index.js
+++ b/apps/epp-replace/fields/index.js
@@ -3,7 +3,6 @@ const dateComponent = require('hof').components.date;
 const poisonsList = require('../../../utilities/constants/poisons.js');
 const countersignatoryYears = require('../../../utilities/constants/countersignatory-years.js');
 const { isValidUkDrivingLicenceNumber, validInternationalPhoneNumber } = require('../../../utilities/helpers');
-const helpers = require('../../../utilities/helpers/index.js');
 
 module.exports = {
   'replace-licence-number': {
@@ -230,7 +229,7 @@ module.exports = {
       'required',
       'notUrl',
       { type: 'minlength', arguments: 16 },
-      helpers.isValidUkDrivingLicenceNumber
+      isValidUkDrivingLicenceNumber
     ],
     className: ['govuk-input', 'govuk-!-width-one-thirds'],
     dependent: {

--- a/apps/epp-replace/fields/index.js
+++ b/apps/epp-replace/fields/index.js
@@ -1,4 +1,5 @@
 const titles = require('../../../utilities/constants/titles');
+const dateComponent = require('hof').components.date;
 const poisonsList = require('../../../utilities/constants/poisons.js');
 const countersignatoryYears = require('../../../utilities/constants/countersignatory-years.js');
 const { isValidUkDrivingLicenceNumber, validInternationalPhoneNumber } = require('../../../utilities/helpers');

--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -146,17 +146,17 @@ module.exports = {
         {
           target: '/upload-british-passport',
           condition: req => req.sessionModel.get('replace-which-document-type') === 'UK-passport',
-          continueOnEdit: false
+          continueOnEdit: true
         },
         {
           target: '/upload-passport',
           condition: req => req.sessionModel.get('replace-which-document-type') === 'EU-passport',
-          continueOnEdit: false
+          continueOnEdit: true
         },
         {
           target: '/upload-driving-licence',
           condition: req => req.sessionModel.get('replace-which-document-type') === 'Uk-driving-licence',
-          continueOnEdit: false
+          continueOnEdit: true
         }
       ]
     },

--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -157,7 +157,7 @@ module.exports = {
           condition: req => req.sessionModel.get('replace-which-document-type') === 'Uk-driving-licence',
           continueOnEdit: false
         }
-        ]
+      ]
     },
     '/upload-british-passport': {
       behaviours: [

--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -103,7 +103,7 @@ module.exports = {
       fields: ['replace-is-details-changed'],
       forks: [
         {
-          target: '/section-nine',
+          target: '/amend-licence',
           condition: {
             field: 'replace-is-details-changed',
             value: 'yes'
@@ -132,11 +132,32 @@ module.exports = {
         'replace-new-lastname',
         'replace-date-new-name-changed'
       ],
-      next: '/section-eleven'
+      next: '/identity-details'
     },
-    '/section-eleven': {
-      fields: ['replace-which-document-type'],
-      next: '/upload-british-passport'
+    '/identity-details': {
+      fields: ['replace-which-document-type',
+        'replace-UK-passport-number',
+        'replace-EU-passport-number',
+        'replace-Uk-driving-licence-number'
+      ],
+      next: '/upload-british-passport',
+      forks: [
+        {
+          target: '/upload-british-passport',
+          condition: req => req.sessionModel.get('replace-which-document-type') === 'UK-passport',
+          continueOnEdit: false
+        },
+        {
+          target: '/upload-passport',
+          condition: req => req.sessionModel.get('replace-which-document-type') === 'EU-passport',
+          continueOnEdit: false
+        },
+        {
+          target: '/upload-driving-licence',
+          condition: req => req.sessionModel.get('replace-which-document-type') === 'Uk-driving-licence',
+          continueOnEdit: false
+        }
+        ]
     },
     '/upload-british-passport': {
       behaviours: [

--- a/apps/epp-replace/sections/summary-data-sections.js
+++ b/apps/epp-replace/sections/summary-data-sections.js
@@ -36,6 +36,22 @@ module.exports = {
   'replace-new-name': {
     steps: [
       {
+        step: '/identity-details',
+        field: 'replace-which-document-type'
+      },
+      {
+        step: '/identity-details',
+        field: 'replace-UK-passport-number'
+      },
+      {
+        step: '/identity-details',
+        field: 'replace-EU-passport-number'
+      },
+      {
+        step: '/identity-details',
+        field: 'replace-Uk-driving-licence-number'
+      },
+      {
         step: '/upload-british-passport',
         field: 'replace-british-passport',
         parse: (documents, req) => {
@@ -103,7 +119,6 @@ module.exports = {
           ) {
             return documents.map(file => file.name);
           }
-
           return null;
         }
       }

--- a/apps/epp-replace/translations/src/en/fields.json
+++ b/apps/epp-replace/translations/src/en/fields.json
@@ -142,5 +142,32 @@
       "replace-date-of-birth": {
         "hint": " For example, 30 09 1969",
         "label": "Date of birth"
+      },
+      "replace-which-document-type": {
+        "legend": "Which identity document do you want to use?",
+        "options": {
+          "UK-passport": {
+            "label": "British passport"
+          },
+          "EU-passport": {
+            "label": "Passport from the EU, Switzerland, Norway, Iceland or Liechtenstein"
+          },
+          "Uk-driving-licence": {
+            "label": "UK driving licence",
+            "hint": "Must be a photocard licence."
+          }
+        }
+      },
+      "replace-UK-passport-number": {
+        "label": "What is your passport number?",
+        "hint" : "For example, 120897A"    
+      },
+      "replace-EU-passport-number": {
+        "label": "What is your passport number?",
+        "hint" : "For example, 120897A"  
+      },
+      "replace-Uk-driving-licence-number": {
+        "label": "What is your driving licence number?",
+        "hint" : "On section 5 of your licence, for example MORGA657054SM9IJ"    
       }
 }

--- a/apps/epp-replace/translations/src/en/pages.json
+++ b/apps/epp-replace/translations/src/en/pages.json
@@ -206,6 +206,18 @@
       },
       "replace-countersignatory-Uk-driving-licence-number": {
         "label": "UK driving licence number"
+      },
+      "replace-which-document-type": {
+        "label": "Identification document"
+      },
+      "replace-UK-passport-number": {
+        "label": "British passport number"
+      },
+      "replace-EU-passport-number": {
+        "label": "Passport number"
+      },
+      "replace-Uk-driving-licence-number": {
+        "label": "UK driving licence number"
       }
     }
   }

--- a/apps/epp-replace/translations/src/en/validation.json
+++ b/apps/epp-replace/translations/src/en/validation.json
@@ -130,5 +130,27 @@
   "required": "Enter your date of birth",
   "date": "Enter a real date",
   "before": "Your date of birth must be in the past"
+  },
+  "replace-which-document-type": {
+    "required": "Select which identity document you want to use"
+  },
+  "replace-UK-passport-number": {
+    "required": "Enter your passport number",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer",
+    "maxlength": "Passport number must be 9 characters or less",
+    "alphanum": "Passport number must only include numbers and letters a-z"
+
+  },
+  "replace-EU-passport-number": {
+    "required": "Enter your passport number",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer", 
+    "maxlength": "Passport number must be 9 characters or less",
+    "alphanum": " Passport number must only include numbers and letters a-z"
+  },
+  "replace-Uk-driving-licence-number": {
+    "required": "Enter your driving licence number",
+    "isValidUkDrivingLicenceNumber": "Enter a real UK driving licence number",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer",
+    "minlength": "Driving licence number must be 16 characters"
   }
 }


### PR DESCRIPTION
## What? 
[EPP-190](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-190) - Create identity details page for Replace - EPP

## Why? 
Allows user to enter which identity they would like to use and the information

## How? 
- Added Heading and inputs for page
- Added validations for page

## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
