### PR TITLE
Epp-170  Poison Details page for amend flow

### DIFF
--- a/apps/epp-amend/fields/index.js
+++ b/apps/epp-amend/fields/index.js
@@ -411,6 +411,88 @@ module.exports = {
       }
     ].concat(poisonsList)
   },
+  'amend-why-need-poison': {
+    mixin: 'textarea',
+    validate: ['required', 'notUrl', helpers.textAreaDefaultLength],
+    attributes: [{ attribute: 'rows', value: 5 }],
+    labelClassName: 'govuk-label--s'
+  },
+  'amend-how-much-poison': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
+    className: ['govuk-input', 'govuk-input--width-10'],
+    labelClassName: 'govuk-label--s'
+  },
+  'amend-compound-or-salt': {
+    mixin: 'textarea',
+    validate: ['required', 'notUrl', helpers.textAreaDefaultLength],
+    attributes: [{ attribute: 'rows', value: 5 }],
+    labelClassName: 'govuk-label--s'
+  },
+  'amend-what-concentration-poison': {
+    mixin: 'input-text',
+    validate: [
+      'required',
+      helpers.isValidConcentrationValue,
+      { type: 'maxlength', arguments: 250 },
+      'notUrl'
+    ],
+    className: ['govuk-input', 'govuk-input--width-5'],
+    labelClassName: 'govuk-label--s',
+    attributes: [{ suffix: '%' }]
+  },
+  'amend-where-to-store-poison': {
+    mixin: 'checkbox-group',
+    validate: ['required'],
+    legend: {
+      className: 'govuk-label--s'
+    },
+    options: [
+      {
+        value: 'amend-store-poison-home-address'
+      },
+      {
+        value: 'amend-store-poison-other-address',
+        toggle: 'store-poison-other-address',
+        child: 'textarea'
+      }
+    ]
+  },
+  'store-poison-other-address': {
+    mixin: 'textarea',
+    validate: ['required', helpers.textAreaDefaultLength, 'notUrl'],
+    dependent: {
+      field: 'amend-where-to-store-poison',
+      value: 'amend-store-poison-other-address'
+    },
+    attributes: [{ attribute: 'rows', value: 5 }]
+  },
+  'amend-where-to-use-poison': {
+    mixin: 'checkbox-group',
+    validate: ['required'],
+    legend: {
+      className: 'govuk-label--s'
+    },
+    options: [
+      {
+        value: 'amend-use-poison-home-address'
+      },
+      {
+        value: 'amend-use-poison-other-address',
+        toggle: 'poison-use-other-address',
+        child: 'textarea'
+      }
+    ]
+  },
+  'poison-use-other-address': {
+    mixin: 'textarea',
+    validate: ['required', helpers.textAreaDefaultLength, 'notUrl'],
+    dependent: {
+      field: 'amend-where-to-use-poison',
+      value: 'amend-use-poison-other-address'
+    },
+    attributes: [{ attribute: 'rows', value: 5 }]
+  },
   'amend-no-poisons-precursors-options': {
     mixin: 'radio-group',
     legend: {

--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -17,6 +17,7 @@ const EditRouteStart = require('../epp-common/behaviours/edit-route-start');
 const EditRouteReturn = require('../epp-common/behaviours/edit-route-return');
 const DeleteRedundantDocuments = require('../epp-common/behaviours/delete-redundant-documents');
 const JourneyValidator = require('../epp-common/behaviours/journey-validator');
+const RenderPoisonDetails = require('../epp-common/behaviours/render-poison-detail');
 const SendNotification = require('../epp-common/behaviours/submit-notify');
 const ParseSummaryPrecursorsPoisons = require('../epp-common/behaviours/parse-summary-precursors-poisons');
 const ModifySummaryChangeLink = require('../epp-common/behaviours/modify-summary-change-links');
@@ -336,18 +337,37 @@ module.exports = {
           target: '/select-poisons',
           continueOnEdit: true,
           condition: {
-            field: 'amend-name-options',
-            value: 'yes'
+            field: 'amend-poisons-options',
+            value: 'no'
           }
         }
       ],
-      next: '/countersignatory-details',
+      next: '/select-poisons',
       locals: { captionHeading: 'Section 16 of 23' }
     },
     '/select-poisons': {
       fields: ['amend-poison'],
-      locals: { captionHeading: 'Section 17 of 23' },
-      next: '/countersignatory-details'
+      next: '/poison-details',
+      locals: { captionHeading: 'Section 17 of 23' }
+    },
+    '/poison-details': {
+      behaviours: [RenderPoisonDetails('amend-poison')],
+      fields: [
+        'amend-why-need-poison',
+        'amend-how-much-poison',
+        'amend-compound-or-salt',
+        'amend-what-concentration-poison',
+        'amend-where-to-store-poison',
+        'amend-where-to-use-poison',
+        'store-poison-other-address',
+        'poison-use-other-address'
+      ],
+      next: '/poisons-summary',
+      locals: { captionHeading: 'Section 17 of 23' }
+    },
+    '/poisons-summary': {
+      next: '/countersignatory-details',
+      locals: { captionHeading: 'Section 17 of 23' }
     },
     '/no-poisons-or-precursors': {
       behaviours: [SetBackLink],

--- a/apps/epp-amend/translations/src/en/fields.json
+++ b/apps/epp-amend/translations/src/en/fields.json
@@ -303,6 +303,52 @@
     "label": "{{values.usePrecursorOtherAddressLabel}}",
     "hint": "Enter a UK address"
   },
+  "amend-why-need-poison":{
+    "label": "{{values.whyNeedPoisonLabel}}",
+    "hint": "Detailed answers mean we can process your application faster"
+  },
+  "amend-how-much-poison":{
+    "label": "How much do you wish to acquire at any one time?",
+    "hint": "Enter the amount and the unit. For example, 10 litres"
+  },
+  "amend-compound-or-salt": {
+    "label": "Specific compound or salt"
+  },
+  "amend-what-concentration-poison":{
+    "label": "What concentration % w/w do you need?"
+  },
+  "amend-where-to-store-poison": {
+    "legend": "{{values.whereToStorePoisonLegend}}",
+    "hint": "This must be in the UK",
+    "options": {
+      "amend-store-poison-home-address": {
+        "label": "{{values.homeAddressInline}}"
+      },
+      "amend-store-poison-other-address": {
+        "label": "Other address"
+      }
+    }
+  },
+  "store-poison-other-address": {
+    "label": "{{values.storePoisonOtherAddressLabel}}",
+    "hint": "Enter a UK address"
+  },
+  "amend-where-to-use-poison": {
+    "legend": "{{values.whereToUsePoisonLegend}}",
+    "hint": "This must be in the UK",
+    "options": {
+      "amend-use-poison-home-address": {
+        "label": "{{values.homeAddressInline}}"
+      },
+      "amend-use-poison-other-address": {
+        "label": "Other address"
+      }
+    }
+  },
+  "poison-use-other-address": {
+    "label": "{{values.usePoisonOtherAddressLabel}}",
+    "hint": "Enter a UK address"
+  },
   "amend-countersignatory-Id-type": {
     "legend": "What is your countersignatory’s identity document?",
     "hint": "You only need to provide a document number.",

--- a/apps/epp-amend/translations/src/en/fields.json
+++ b/apps/epp-amend/translations/src/en/fields.json
@@ -259,13 +259,13 @@
     "summary-heading": "{{values.whyNeedPrecursorLabel}}"
   },
   "amend-how-much-precursor":{
-    "label": "How much do you wish to acquire at any one time?",
+    "label": "How much do you wish to acquire at any one time within a 6-month period?",
     "hint": "Enter the amount and the unit. For example, 10 litres",
     "summary-heading": "How much do you wish to acquire at any one time?"
   },
   "amend-what-concentration-precursor":{
     "label": "What concentration % w/w do you need?",
-    "summary-heading": "What concentration % w/w do you need?"
+    "summary-heading": "What concentration % w/w of the substance do you need?"
   },
   "amend-where-to-store-precursor": {
     "legend": "{{values.whereToStorePrecursorLegend}}",
@@ -308,14 +308,14 @@
     "hint": "Detailed answers mean we can process your application faster"
   },
   "amend-how-much-poison":{
-    "label": "How much do you wish to acquire at any one time?",
+    "label": "How much do you wish to acquire at any one time within a 6-month period?",
     "hint": "Enter the amount and the unit. For example, 10 litres"
   },
   "amend-compound-or-salt": {
     "label": "Specific compound or salt"
   },
   "amend-what-concentration-poison":{
-    "label": "What concentration % w/w do you need?"
+    "label": "What concentration % w/w of the substance do you need?"
   },
   "amend-where-to-store-poison": {
     "legend": "{{values.whereToStorePoisonLegend}}",

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -150,6 +150,9 @@
     "p1": "Tell us which poisons you want to import acquire use or possess.",
     "p2": "If you need multiple poisons, you can add each one separately."
   },
+  "poison-details":{
+    "header": "{{values.amend-poison}}"
+  },
   "no-poisons-or-precursors": {
     "header": "The explosives precursors and poisons on your licence will not change",
     "paragraph1": "You told us you do not need to amend the explosives precursors or poisons on your current licence. This includes the storage or usage address for the substances."

--- a/apps/epp-amend/translations/src/en/validation.json
+++ b/apps/epp-amend/translations/src/en/validation.json
@@ -210,6 +210,43 @@
   "amend-poison":{
     "required": "Select a poison"
   },
+  "amend-why-need-poison": {
+    "required": "Explain why you need this poison",
+    "textAreaDefaultLength": "Reason why you need this poison must be less than 2,000 characters",
+    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "amend-how-much-poison": {
+    "required": "Enter how much of poison you wish to acquire at any one time",
+    "maxlength": "Quantity of the explosive precursor you wish to acquire must be 250 characters or less",
+    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "amend-compound-or-salt": {
+     "required": "Enter the specific compound or salt",
+     "textAreaDefaultLength": " Specific compound or salt must be less than 2,000 characters",
+     "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "amend-what-concentration-poison": {
+    "required": "Enter what concentration % w/w you need",
+    "isValidConcentrationValue" : "Concentration % w/w must only include numbers or special characters",
+    "maxlength": "Concentration % w/w must be 250 characters or less",
+    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "amend-where-to-store-poison": {
+    "required": "Select where you will store the poison"
+  },
+  "amend-where-to-use-poison": {
+    "required": "Select where you will use the poison"
+  },
+  "store-poison-other-address": {
+    "required": "Enter the address where you will store the poison",
+    "textAreaDefaultLength": "Storage address must be 2,000 characters or less",
+    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "poison-use-other-address": {
+    "required": "Enter the address where you will use the poison",
+    "textAreaDefaultLength": "Usage address must be 2,000 characters or less",
+    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
   "amend-no-poisons-precursors-options": {
     "required": "Select if you want to continue the form without changing the explosives precursors or poisons"
   },

--- a/apps/epp-common/behaviours/aggregator-save-update-precursors-poisons.js
+++ b/apps/epp-common/behaviours/aggregator-save-update-precursors-poisons.js
@@ -1,4 +1,5 @@
-const { DEFAULT_AGGREGATOR_LIMIT, getPrecursorsShortLabel } = require('../../../utilities/helpers');
+const { SUBSTANCES } = require('../../../utilities/constants/string-constants');
+const { DEFAULT_AGGREGATOR_LIMIT, getSubstanceShortLabel } = require('../../../utilities/helpers');
 
 module.exports = superclass => class extends superclass {
   constructor(options) {
@@ -56,7 +57,7 @@ module.exports = superclass => class extends superclass {
 
 
       if (!isTitleField && itemTitle.length === 0) {
-        itemTitle.push(getPrecursorsShortLabel(req.sessionModel.get('amend-precursor-field')));
+        itemTitle.push(getSubstanceShortLabel(req.sessionModel.get('amend-precursor-field'), SUBSTANCES.PRECURSOR));
       }
 
       fields.push({

--- a/apps/epp-common/behaviours/render-poison-detail.js
+++ b/apps/epp-common/behaviours/render-poison-detail.js
@@ -1,0 +1,40 @@
+const { getPoisonShortLabel } = require('../../../utilities/helpers');
+
+/**
+ * @param {string} fieldName - The field name used on the select precursor page
+ */
+module.exports = fieldName => superclass =>
+  class extends superclass {
+    getValues(req, res, next) {
+      const selectedPoison = req.sessionModel.get(fieldName);
+      const whyNeedPoisonLabel = getPoisonShortLabel(
+        `Why do you need ${selectedPoison}`
+      );
+      const whereToStorePoisonLegend = getPoisonShortLabel(
+        `Where will you store the ${selectedPoison}`
+      );
+      const whereToUsePoisonLegend = getPoisonShortLabel(
+        `Where will you use the ${selectedPoison}`
+      );
+      const storePoisonOtherAddressLabel = getPoisonShortLabel(
+        `Storage address for the ${selectedPoison}`
+      );
+      const usePoisonOtherAddressLabel = getPoisonShortLabel(
+        `Usage address for the ${selectedPoison}`
+      );
+
+      const labelValuesMap = {
+        whyNeedPoisonLabel: whyNeedPoisonLabel,
+        whereToStorePoisonLegend: whereToStorePoisonLegend,
+        whereToUsePoisonLegend: whereToUsePoisonLegend,
+        storePoisonOtherAddressLabel: storePoisonOtherAddressLabel,
+        usePoisonOtherAddressLabel: usePoisonOtherAddressLabel
+      };
+
+      Object.entries(labelValuesMap).forEach(([key, value]) => {
+        req.sessionModel.set(key, value);
+      });
+
+      return super.getValues(req, res, next);
+    }
+  };

--- a/apps/epp-common/behaviours/render-poison-detail.js
+++ b/apps/epp-common/behaviours/render-poison-detail.js
@@ -1,4 +1,7 @@
-const { getPoisonShortLabel } = require('../../../utilities/helpers');
+const {
+  SUBSTANCES: { POISON }
+} = require('../../../utilities/constants/string-constants');
+const { getSubstanceShortLabel } = require('../../../utilities/helpers');
 
 /**
  * @param {string} fieldName - The field name used on the select precursor page
@@ -7,20 +10,25 @@ module.exports = fieldName => superclass =>
   class extends superclass {
     getValues(req, res, next) {
       const selectedPoison = req.sessionModel.get(fieldName);
-      const whyNeedPoisonLabel = getPoisonShortLabel(
-        `Why do you need ${selectedPoison}`
+      const whyNeedPoisonLabel = getSubstanceShortLabel(
+        `Why do you need ${selectedPoison}`,
+        POISON
       );
-      const whereToStorePoisonLegend = getPoisonShortLabel(
-        `Where will you store the ${selectedPoison}`
+      const whereToStorePoisonLegend = getSubstanceShortLabel(
+        `Where will you store the ${selectedPoison}`,
+        POISON
       );
-      const whereToUsePoisonLegend = getPoisonShortLabel(
-        `Where will you use the ${selectedPoison}`
+      const whereToUsePoisonLegend = getSubstanceShortLabel(
+        `Where will you use the ${selectedPoison}`,
+        POISON
       );
-      const storePoisonOtherAddressLabel = getPoisonShortLabel(
-        `Storage address for the ${selectedPoison}`
+      const storePoisonOtherAddressLabel = getSubstanceShortLabel(
+        `Storage address for the ${selectedPoison}`,
+        POISON
       );
-      const usePoisonOtherAddressLabel = getPoisonShortLabel(
-        `Usage address for the ${selectedPoison}`
+      const usePoisonOtherAddressLabel = getSubstanceShortLabel(
+        `Usage address for the ${selectedPoison}`,
+        POISON
       );
 
       const labelValuesMap = {

--- a/apps/epp-common/behaviours/render-precursors-detail.js
+++ b/apps/epp-common/behaviours/render-precursors-detail.js
@@ -1,4 +1,7 @@
-const { getPrecursorsShortLabel } = require('../../../utilities/helpers');
+const { getSubstanceShortLabel } = require('../../../utilities/helpers');
+const {
+  SUBSTANCES: { PRECURSOR }
+} = require('../../../utilities/constants/string-constants');
 
 /**
  * @param {string} fieldName - The field name used on the select precursor page
@@ -7,20 +10,20 @@ module.exports = fieldName => superclass =>
   class extends superclass {
     getValues(req, res, next) {
       const selectedPrecursor = req.sessionModel.get(fieldName);
-      const whyNeedPrecursorLabel = getPrecursorsShortLabel(
-        `Why do you need ${selectedPrecursor}`
+      const whyNeedPrecursorLabel = getSubstanceShortLabel(
+        `Why do you need ${selectedPrecursor}`, PRECURSOR
       );
-      const whereToStorePrecursorLegend = getPrecursorsShortLabel(
-        `Where will you store the ${selectedPrecursor}`
+      const whereToStorePrecursorLegend = getSubstanceShortLabel(
+        `Where will you store the ${selectedPrecursor}`, PRECURSOR
       );
-      const whereToUsePrecursorLegend = getPrecursorsShortLabel(
-        `Where will you use the ${selectedPrecursor}`
+      const whereToUsePrecursorLegend = getSubstanceShortLabel(
+        `Where will you use the ${selectedPrecursor}`, PRECURSOR
       );
-      const storePrecursorOtherAddressLabel = getPrecursorsShortLabel(
-        `Storage address for the ${selectedPrecursor}`
+      const storePrecursorOtherAddressLabel = getSubstanceShortLabel(
+        `Storage address for the ${selectedPrecursor}`, PRECURSOR
       );
-      const usePrecursorOtherAddressLabel = getPrecursorsShortLabel(
-        `Usage address for the ${selectedPrecursor}`
+      const usePrecursorOtherAddressLabel = getSubstanceShortLabel(
+        `Usage address for the ${selectedPrecursor}`, PRECURSOR
       );
 
       const labelValuesMap = {

--- a/test/unit/behaviours/aggregator-save-update-precursors-poisons.spec.js
+++ b/test/unit/behaviours/aggregator-save-update-precursors-poisons.spec.js
@@ -1,7 +1,7 @@
 const proxyquire = require('proxyquire');
 const helpersStub = {
   DEFAULT_AGGREGATOR_LIMIT: 5,
-  getPrecursorsShortLabel: sinon.stub().returns('short-label')
+  getSubstanceShortLabel: sinon.stub().returns('short-label')
 };
 
 const Behaviour = proxyquire(

--- a/test/unit/utilities/utilities.spec.js
+++ b/test/unit/utilities/utilities.spec.js
@@ -9,13 +9,15 @@ const {
   removeWhiteSpace,
   getFormattedDate,
   isEditMode,
-  getPrecursorsShortLabel,
+  getSubstanceShortLabel,
   textAreaDefaultLength,
   isValidConcentrationValue,
   isLicenceValid
 } = require('../../../utilities/helpers');
 
 const explosivePrecursorsList = require('../../../utilities/constants/explosive-precursors');
+const poisonsList = require('../../../utilities/constants/poisons');
+const { SUBSTANCES } = require('../../../utilities/constants/string-constants');
 
 describe('EPP utilities tests', () => {
   it('.validLicenceNumber - should match for valid formats', () => {
@@ -216,61 +218,80 @@ describe('EPP utilities tests', () => {
     }
   });
 
-  it('.getPrecursorsShortLabel - should return the shortLabel for the given precursors label', () => {
+  it('.getSubstanceShortLabel - should return the shortLabel for the given precursors label', () => {
     for (const explosivePrecursors of explosivePrecursorsList) {
-      expect(getPrecursorsShortLabel(explosivePrecursors.label)).to.be.equal(
-        explosivePrecursors.shortLabel
-      );
+      expect(
+        getSubstanceShortLabel(explosivePrecursors.label, SUBSTANCES.PRECURSOR)
+      ).to.be.equal(explosivePrecursors.shortLabel);
     }
   });
 
-  it('.getPrecursorsShortLabel - should return a partial replaced value with shortLabel', () => {
+  it('.getSubstanceShortLabel - should return the shortLabel for the given poison label', () => {
+    for (const poison of poisonsList) {
+      expect(
+        getSubstanceShortLabel(poison.label, SUBSTANCES.POISON)
+      ).to.be.equal(poison.shortLabel);
+    }
+  });
+
+  it('.getSubstanceShortLabel - should return a partial replaced value with shortLabel', () => {
     for (const explosivePrecursors of explosivePrecursorsList) {
       expect(
-        getPrecursorsShortLabel(`Why do you need ${explosivePrecursors.label}`)
+        getSubstanceShortLabel(
+          `Why do you need ${explosivePrecursors.label}`,
+          SUBSTANCES.PRECURSOR
+        )
       ).to.be.equal(`Why do you need ${explosivePrecursors.shortLabel}`);
 
       expect(
-        getPrecursorsShortLabel(
-          `Where will you store the ${explosivePrecursors.label}`
+        getSubstanceShortLabel(
+          `Where will you store the ${explosivePrecursors.label}`,
+          SUBSTANCES.PRECURSOR
         )
       ).to.be.equal(
         `Where will you store the ${explosivePrecursors.shortLabel}`
       );
 
       expect(
-        getPrecursorsShortLabel(
-          `Where will you use the ${explosivePrecursors.label}`
+        getSubstanceShortLabel(
+          `Where will you use the ${explosivePrecursors.label}`,
+          SUBSTANCES.PRECURSOR
         )
       ).to.be.equal(`Where will you use the ${explosivePrecursors.shortLabel}`);
 
       expect(
-        getPrecursorsShortLabel(
-          `Storage address for the ${explosivePrecursors.label}`
+        getSubstanceShortLabel(
+          `Storage address for the ${explosivePrecursors.label}`,
+          SUBSTANCES.PRECURSOR
         )
       ).to.be.equal(
         `Storage address for the ${explosivePrecursors.shortLabel}`
       );
 
       expect(
-        getPrecursorsShortLabel(
-          `Usage address for the ${explosivePrecursors.label}`
+        getSubstanceShortLabel(
+          `Usage address for the ${explosivePrecursors.label}`,
+          SUBSTANCES.PRECURSOR
         )
       ).to.be.equal(`Usage address for the ${explosivePrecursors.shortLabel}`);
     }
   });
 
-  it('.getPrecursorsShortLabel - should return original result for falsy or non string inputs', () => {
+  it('.getSubstanceShortLabel - should return original result for falsy or non string inputs', () => {
     const inputs = [null, undefined, '', 1, true, {}];
     for (const input of inputs) {
-      expect(getPrecursorsShortLabel(input)).to.be.equal(input);
+      expect(getSubstanceShortLabel(input, SUBSTANCES.PRECURSOR)).to.be.equal(
+        input
+      );
     }
   });
 
-  it('.getPrecursorsShortLabel - should return original result for unknown strings', () => {
+  it('.getSubstanceShortLabel - should return original result for unknown strings', () => {
     const inputs = ['Hello World', 'Unit test', 'random-text'];
     for (const input of inputs) {
-      expect(getPrecursorsShortLabel(input)).to.be.equal(input);
+      expect(getSubstanceShortLabel(input, SUBSTANCES.PRECURSOR)).to.be.equal(
+        input
+      );
     }
   });
 

--- a/utilities/constants/string-constants.js
+++ b/utilities/constants/string-constants.js
@@ -23,6 +23,11 @@ const API_METHODS = {
   POST: 'POST'
 };
 
+const SUBSTANCES = {
+  PRECURSOR: 'precursor',
+  POISON: 'poison'
+};
+
 module.exports = {
   PATH_NEW_RENEW,
   PATH_AMEND,
@@ -41,5 +46,6 @@ module.exports = {
   GOV_PAY_ERROR_CODE_P0030,
   GOV_PAY_ERROR_CODE_P0010,
   GOV_PAY_STATUS_SUCCESS,
-  API_METHODS
+  API_METHODS,
+  SUBSTANCES
 };

--- a/utilities/helpers/index.js
+++ b/utilities/helpers/index.js
@@ -3,6 +3,7 @@ const validators = require('hof/controller/validation/validators');
 const explosivePrecursorsList = require('../constants/explosive-precursors');
 const poisonList = require('../constants/poisons');
 const config = require('../../config');
+const { SUBSTANCES } = require('../constants/string-constants');
 
 class NotifyMock {
   sendEmail() {
@@ -127,40 +128,23 @@ const isEditMode = req => {
   return Boolean(req?.originalUrl?.endsWith('/edit'));
 };
 
-const getPrecursorsShortLabel = input => {
-  if (!input || typeof input !== 'string') {
+const getSubstanceShortLabel = (input, substance) => {
+  if (!input || typeof input !== 'string' || !substance) {
     return input;
   }
 
   const resultStr = input.trim();
 
-  for (const { label, shortLabel } of explosivePrecursorsList) {
+  const list =
+    substance === SUBSTANCES.POISON ? poisonList : explosivePrecursorsList;
+
+  for (const { label, shortLabel } of list) {
     if (resultStr === label) {
       return shortLabel;
     }
 
     if (resultStr.includes(label)) {
-      const newLabel = resultStr.replace(label, shortLabel);
-      return newLabel;
-    }
-  }
-  return resultStr;
-};
-const getPoisonShortLabel = input => {
-  if (!input || typeof input !== 'string') {
-    return input;
-  }
-
-  const resultStr = input.trim();
-
-  for (const { label, shortLabel } of poisonList) {
-    if (resultStr === label) {
-      return shortLabel;
-    }
-
-    if (resultStr.includes(label)) {
-      const newLabel = resultStr.replace(label, shortLabel);
-      return newLabel;
+      return resultStr.replace(label, shortLabel);
     }
   }
   return resultStr;
@@ -181,8 +165,7 @@ module.exports = {
   DATE_FORMAT_YYYY_MM_DD,
   getFormattedDate,
   isEditMode,
-  getPrecursorsShortLabel,
-  getPoisonShortLabel,
+  getSubstanceShortLabel,
   textAreaDefaultLength,
   isValidConcentrationValue,
   NotifyClient:

--- a/utilities/helpers/index.js
+++ b/utilities/helpers/index.js
@@ -1,6 +1,7 @@
 const moment = require('moment');
 const validators = require('hof/controller/validation/validators');
 const explosivePrecursorsList = require('../constants/explosive-precursors');
+const poisonList = require('../constants/poisons');
 const config = require('../../config');
 
 class NotifyMock {
@@ -145,6 +146,25 @@ const getPrecursorsShortLabel = input => {
   }
   return resultStr;
 };
+const getPoisonShortLabel = input => {
+  if (!input || typeof input !== 'string') {
+    return input;
+  }
+
+  const resultStr = input.trim();
+
+  for (const { label, shortLabel } of poisonList) {
+    if (resultStr === label) {
+      return shortLabel;
+    }
+
+    if (resultStr.includes(label)) {
+      const newLabel = resultStr.replace(label, shortLabel);
+      return newLabel;
+    }
+  }
+  return resultStr;
+};
 
 module.exports = {
   isLicenceValid,
@@ -162,6 +182,7 @@ module.exports = {
   getFormattedDate,
   isEditMode,
   getPrecursorsShortLabel,
+  getPoisonShortLabel,
   textAreaDefaultLength,
   isValidConcentrationValue,
   NotifyClient:


### PR DESCRIPTION
## What? 
Create a poison details page as per jira ticket [EPP-170](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-170)
## Why? 
to allow user to provide details about the poison on the licence that needs to be amended
## How? 
- add `fields` for poison details page in 
   - `index.js`, 
   - `fields/index.js`, 
   - ` fields.json`, 
   - `page,json`, 
   -`validation.json`
- update `utilities/helpers/index.js` with custom trimming method for poison
- create behaviour `render-poison-detail.js` to render poison's details
## Testing?
manual
## Screenshots (optional)
## Anything Else? (optional)
**NB** the confirm summary page will be worked in ticket EPP-172, since this page has a mid-journey summary page (`poisons-summary page`). 
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
