### PR TITLE
EPP-278 BUG - added section number to home address for replace

### DIFF
--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -111,6 +111,7 @@ module.exports = {
         'replace-home-postcode',
         'replace-home-country'
       ],
+      locals: { captionHeading: 'Section 6 of 26' },
       next: '/contact-details'
     },
     '/contact-details': {


### PR DESCRIPTION
## What? 
[EPP-278](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-278) - Added section number to home address page (section 6) for Replace - EPP

## Why? 
Section number was not added in previous ticket (EPP-186)

## How? 
Added section number in the index file.

## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging