### PR TITLE
EPP-205 replace - POISON DETAILS

### DIFF
--- a/apps/epp-amend/fields/index.js
+++ b/apps/epp-amend/fields/index.js
@@ -411,25 +411,25 @@ module.exports = {
       }
     ].concat(poisonsList)
   },
-  'amend-why-need-poison': {
+  'why-need-poison': {
     mixin: 'textarea',
     validate: ['required', 'notUrl', helpers.textAreaDefaultLength],
     attributes: [{ attribute: 'rows', value: 5 }],
     labelClassName: 'govuk-label--s'
   },
-  'amend-how-much-poison': {
+  'how-much-poison': {
     mixin: 'input-text',
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
     className: ['govuk-input', 'govuk-input--width-10'],
     labelClassName: 'govuk-label--s'
   },
-  'amend-compound-or-salt': {
+  'compound-or-salt': {
     mixin: 'textarea',
     validate: ['required', 'notUrl', helpers.textAreaDefaultLength],
     attributes: [{ attribute: 'rows', value: 5 }],
     labelClassName: 'govuk-label--s'
   },
-  'amend-what-concentration-poison': {
+  'what-concentration-poison': {
     mixin: 'input-text',
     validate: [
       'required',
@@ -441,7 +441,7 @@ module.exports = {
     labelClassName: 'govuk-label--s',
     attributes: [{ suffix: '%' }]
   },
-  'amend-where-to-store-poison': {
+  'where-to-store-poison': {
     mixin: 'checkbox-group',
     validate: ['required'],
     legend: {
@@ -449,10 +449,10 @@ module.exports = {
     },
     options: [
       {
-        value: 'amend-store-poison-home-address'
+        value: 'store-poison-home-address-value'
       },
       {
-        value: 'amend-store-poison-other-address',
+        value: 'store-poison-other-address-value',
         toggle: 'store-poison-other-address',
         child: 'textarea'
       }
@@ -462,12 +462,12 @@ module.exports = {
     mixin: 'textarea',
     validate: ['required', helpers.textAreaDefaultLength, 'notUrl'],
     dependent: {
-      field: 'amend-where-to-store-poison',
-      value: 'amend-store-poison-other-address'
+      field: 'where-to-store-poison',
+      value: 'store-poison-other-address-value'
     },
     attributes: [{ attribute: 'rows', value: 5 }]
   },
-  'amend-where-to-use-poison': {
+  'where-to-use-poison': {
     mixin: 'checkbox-group',
     validate: ['required'],
     legend: {
@@ -475,10 +475,10 @@ module.exports = {
     },
     options: [
       {
-        value: 'amend-use-poison-home-address'
+        value: 'use-poison-home-address'
       },
       {
-        value: 'amend-use-poison-other-address',
+        value: 'use-poison-other-address-value',
         toggle: 'poison-use-other-address',
         child: 'textarea'
       }
@@ -488,8 +488,8 @@ module.exports = {
     mixin: 'textarea',
     validate: ['required', helpers.textAreaDefaultLength, 'notUrl'],
     dependent: {
-      field: 'amend-where-to-use-poison',
-      value: 'amend-use-poison-other-address'
+      field: 'where-to-use-poison',
+      value: 'use-poison-other-address-value'
     },
     attributes: [{ attribute: 'rows', value: 5 }]
   },

--- a/apps/epp-amend/fields/index.js
+++ b/apps/epp-amend/fields/index.js
@@ -399,7 +399,7 @@ module.exports = {
     options: ['yes', 'no'],
     validate: 'required'
   },
-  'amend-poison': {
+  'poison-field': {
     mixin: 'select',
     validate: ['required'],
     labelClassName: 'visuallyhidden',
@@ -407,7 +407,7 @@ module.exports = {
     options: [
       {
         value: '',
-        label: 'fields.amend-poison.options.none_selected'
+        label: 'fields.poison-field.options.none_selected'
       }
     ].concat(poisonsList)
   },

--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -367,12 +367,12 @@ module.exports = {
     '/poison-details': {
       behaviours: [RenderPoisonDetails('amend-poison')],
       fields: [
-        'amend-why-need-poison',
-        'amend-how-much-poison',
-        'amend-compound-or-salt',
-        'amend-what-concentration-poison',
-        'amend-where-to-store-poison',
-        'amend-where-to-use-poison',
+        'why-need-poison',
+        'how-much-poison',
+        'compound-or-salt',
+        'what-concentration-poison',
+        'where-to-store-poison',
+        'where-to-use-poison',
         'store-poison-other-address',
         'poison-use-other-address'
       ],
@@ -389,12 +389,12 @@ module.exports = {
       aggregateTo: 'poisons-details-aggregate',
       aggregateFrom: [
         'amend-display-poison-title',
-        'amend-why-need-poison',
-        'amend-how-much-poison',
-        'amend-compound-or-salt',
-        'amend-what-concentration-poison',
-        'amend-where-to-store-poison',
-        'amend-where-to-use-poison'
+        'why-need-poison',
+        'how-much-poison',
+        'compound-or-salt',
+        'what-concentration-poison',
+        'where-to-store-poison',
+        'where-to-use-poison'
       ],
       titleField: ['amend-poison'],
       addStep: 'select-poisons',

--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -388,7 +388,7 @@ module.exports = {
       ],
       aggregateTo: 'poisons-details-aggregate',
       aggregateFrom: [
-        'amend-display-poison-title',
+        'display-poison-title',
         'why-need-poison',
         'how-much-poison',
         'compound-or-salt',

--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -359,13 +359,13 @@ module.exports = {
       locals: { captionHeading: 'Section 16 of 23' }
     },
     '/select-poisons': {
-      fields: ['amend-poison'],
+      fields: ['poison-field'],
       next: '/poison-details',
       continueOnEdit: true,
       locals: { captionHeading: 'Section 17 of 23' }
     },
     '/poison-details': {
-      behaviours: [RenderPoisonDetails('amend-poison')],
+      behaviours: [RenderPoisonDetails('poison-field')],
       fields: [
         'why-need-poison',
         'how-much-poison',
@@ -396,7 +396,7 @@ module.exports = {
         'where-to-store-poison',
         'where-to-use-poison'
       ],
-      titleField: ['amend-poison'],
+      titleField: ['poison-field'],
       addStep: 'select-poisons',
       addAnotherLinkText: 'poison',
       continueOnEdit: false,

--- a/apps/epp-amend/sections/summary-data-sections.js
+++ b/apps/epp-amend/sections/summary-data-sections.js
@@ -311,7 +311,7 @@ module.exports = {
           if (!list?.aggregatedValues) { return null; }
           for(const item of list.aggregatedValues) {
             item.fields.map(element => {
-              if(element.field === 'amend-display-poison-title') {
+              if(element.field === 'display-poison-title') {
                 element.parsed = item.joinTitle;
               }else{
                 element.field;

--- a/apps/epp-amend/translations/src/en/fields.json
+++ b/apps/epp-amend/translations/src/en/fields.json
@@ -178,7 +178,7 @@
       }
     }
   },
-  "amend-poison": {
+  "poison-field": {
     "hint": "Select a poison",
       "options":{
         "none_selected": "Select poison"

--- a/apps/epp-amend/translations/src/en/fields.json
+++ b/apps/epp-amend/translations/src/en/fields.json
@@ -303,33 +303,33 @@
     "label": "{{values.usePrecursorOtherAddressLabel}}",
     "hint": "Enter a UK address"
   },
-  "amend-why-need-poison":{
+  "why-need-poison":{
     "label": "{{values.whyNeedPoisonLabel}}",
     "hint": "Detailed answers mean we can process your application faster",
     "summary-heading": "{{values.whyNeedPoisonLabel}}"
   },
-  "amend-how-much-poison":{
+  "how-much-poison":{
     "label": "How much do you wish to acquire at any one time within a 6-month period?",
     "hint": "Enter the amount and the unit. For example, 10 litres",
     "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
   },
-  "amend-compound-or-salt": {
+  "compound-or-salt": {
     "label": "Specific compound or salt",
     "summary-heading": "Specific compound or salt"
   },
-  "amend-what-concentration-poison":{
+  "what-concentration-poison":{
     "label": "What concentration % w/w of the substance do you need?",
     "summary-heading": "What concentration % w/w of the substance do you need?"
   },
-  "amend-where-to-store-poison": {
+  "where-to-store-poison": {
     "legend": "{{values.whereToStorePoisonLegend}}",
     "hint": "This must be in the UK",
     "summary-heading": "{{values.whereToStorePoisonLegend}}",
     "options": {
-      "amend-store-poison-home-address": {
+      "store-poison-home-address-value": {
         "label": "{{values.homeAddressInline}}"
       },
-      "amend-store-poison-other-address": {
+      "store-poison-other-address-value": {
         "label": "Other address"
       }
     }
@@ -338,15 +338,15 @@
     "label": "{{values.storePoisonOtherAddressLabel}}",
     "hint": "Enter a UK address"
   },
-  "amend-where-to-use-poison": {
+  "where-to-use-poison": {
     "legend": "{{values.whereToUsePoisonLegend}}",
     "hint": "This must be in the UK",
     "summary-heading": "{{values.whereToUsePoisonLegend}}",
     "options": {
-      "amend-use-poison-home-address": {
+      "use-poison-home-address": {
         "label": "{{values.homeAddressInline}}"
       },
-      "amend-use-poison-other-address": {
+      "use-poison-other-address-value": {
         "label": "Other address"
       }
     }

--- a/apps/epp-amend/translations/src/en/fields.json
+++ b/apps/epp-amend/translations/src/en/fields.json
@@ -264,7 +264,7 @@
     "summary-heading": "How much do you wish to acquire at any one time?"
   },
   "amend-what-concentration-precursor":{
-    "label": "What concentration % w/w do you need?",
+    "label": "What concentration % w/w of the substance do you need?",
     "summary-heading": "What concentration % w/w of the substance do you need?"
   },
   "amend-where-to-store-precursor": {

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -343,7 +343,7 @@
       "poison-field": {
         "label": "Poison"
       },
-      "amend-display-poison-title": {
+      "display-poison-title": {
          "label": "Poison name"
       },
       "why-need-poison": {

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -151,7 +151,7 @@
     "p2": "If you need multiple poisons, you can add each one separately."
   },
   "poison-details":{
-    "header": "{{values.amend-poison}}"
+    "header": "{{values.poison-field}}"
   },
   "poison-summary": {
     "header": "Poisons on your licence"
@@ -340,7 +340,7 @@
       "amend-regulated-explosives-precursors": {
         "label": "Does your licence need to cover explosives precursors?"
       },
-      "amend-poison": {
+      "poison-field": {
         "label": "Poison"
       },
       "amend-display-poison-title": {

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -346,22 +346,22 @@
       "amend-display-poison-title": {
          "label": "Poison name"
       },
-      "amend-why-need-poison": {
+      "why-need-poison": {
         "label": "For what purpose do you need this regulated substance?"
       },
-      "amend-how-much-poison": {
+      "how-much-poison": {
         "label": "How much do you wish to acquire?"
       },
-      "amend-compound-or-salt": {
+      "compound-or-salt": {
         "label": "Specific compound or salt"
       },
-      "amend-what-concentration-poison": {
+      "what-concentration-poison": {
         "label": "What concentration % w/w of the substance do you need for your intended purpose?"
       },
-      "amend-where-to-store-poison": {
+      "where-to-store-poison": {
         "label":"Storage address"
       },
-      "amend-where-to-use-poison": {
+      "where-to-use-poison": {
         "label": "Usage address"
       },
       "amend-countersignatory-middlename": {

--- a/apps/epp-amend/translations/src/en/validation.json
+++ b/apps/epp-amend/translations/src/en/validation.json
@@ -210,31 +210,31 @@
   "amend-poison":{
     "required": "Select a poison"
   },
-  "amend-why-need-poison": {
+  "why-need-poison": {
     "required": "Explain why you need this poison",
     "textAreaDefaultLength": "Reason why you need this poison must be less than 2,000 characters",
     "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
-  "amend-how-much-poison": {
+  "how-much-poison": {
     "required": "Enter how much of poison you wish to acquire at any one time",
     "maxlength": "Quantity of the explosive precursor you wish to acquire must be 250 characters or less",
     "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
-  "amend-compound-or-salt": {
+  "compound-or-salt": {
      "required": "Enter the specific compound or salt",
      "textAreaDefaultLength": " Specific compound or salt must be less than 2,000 characters",
      "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
-  "amend-what-concentration-poison": {
+  "what-concentration-poison": {
     "required": "Enter what concentration % w/w you need",
     "isValidConcentrationValue" : "Concentration % w/w must only include numbers or special characters",
     "maxlength": "Concentration % w/w must be 250 characters or less",
     "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
-  "amend-where-to-store-poison": {
+  "where-to-store-poison": {
     "required": "Select where you will store the poison"
   },
-  "amend-where-to-use-poison": {
+  "where-to-use-poison": {
     "required": "Select where you will use the poison"
   },
   "store-poison-other-address": {

--- a/apps/epp-amend/translations/src/en/validation.json
+++ b/apps/epp-amend/translations/src/en/validation.json
@@ -207,7 +207,7 @@
   "amend-poisons-option": {
     "required": "Select if your licence needs to cover poisons"
   },
-  "amend-poison":{
+  "poison-field":{
     "required": "Select a poison"
   },
   "why-need-poison": {

--- a/apps/epp-amend/views/content/amend-details-content.md
+++ b/apps/epp-amend/views/content/amend-details-content.md
@@ -5,4 +5,4 @@ You can only use this form to amend these details on your licence:
 - address
 - substances - including if your storage or usage address has changed
 
-If you need to make any other changes to your licence, email the Explosives Procursors and Poisons Licensing Unit at <a class="govuk-link" href="mailto:epp@homeoffice.pnn.police.uk">epp@homeoffice.pnn.police.uk</a>
+If you need to make any other changes to your licence, email the Explosives Precursors and Poisons Licensing Unit at <a class="govuk-link" href="mailto:epp@homeoffice.pnn.police.uk">epp@homeoffice.pnn.police.uk</a>

--- a/apps/epp-amend/views/no-details-amend.html
+++ b/apps/epp-amend/views/no-details-amend.html
@@ -9,7 +9,7 @@
     </ul>
 </div>
 <div class="govuk-inset-text">
-    {{#t}}pages.no-details-amend.insetText{{/t}} <a class="govuk-link" target="_blank" rel="noreferrer noopener" href="mailto:epp@homeoffice.pnn.police.uk">{{#t}}pages.no-details-amend.linkText{{/t}}</a>
+    {{#t}}pages.no-details-amend.insetText{{/t}} <a class="govuk-link" href="mailto:epp@homeoffice.pnn.police.uk">{{#t}}pages.no-details-amend.linkText{{/t}}</a>
 </div>
   {{/page-content}}
 {{/partials-page}}

--- a/apps/epp-common/behaviours/aggregator-save-update-precursors-poisons.js
+++ b/apps/epp-common/behaviours/aggregator-save-update-precursors-poisons.js
@@ -57,10 +57,10 @@ module.exports = superclass => class extends superclass {
 
 
       if(!isTitleField && itemTitle.length === 0 && req.originalUrl.includes('/precursors-summary')) {
-        itemTitle.push(getSubstanceShortLabel(req.sessionModel.get('amend-precursor-field'), SUBSTANCES.PRECURSOR));
+        itemTitle.push(getSubstanceShortLabel(req.sessionModel.get('precursor-field'), SUBSTANCES.PRECURSOR));
       }
       if(!isTitleField && itemTitle.length === 0 && req.originalUrl.includes('/poison-summary')) {
-        itemTitle.push(getSubstanceShortLabel(req.sessionModel.get('amend-poison'), SUBSTANCES.POISON));
+        itemTitle.push(getSubstanceShortLabel(req.sessionModel.get('poison-field'), SUBSTANCES.POISON));
       }
 
       fields.push({

--- a/apps/epp-common/behaviours/aggregator-save-update-precursors-poisons.js
+++ b/apps/epp-common/behaviours/aggregator-save-update-precursors-poisons.js
@@ -209,25 +209,25 @@ module.exports = superclass => class extends superclass {
     const storePoisonOtherAddress = req.sessionModel.get('store-poison-other-address');
     const poisonUseOtherAddress = req.sessionModel.get('poison-use-other-address');
     if (Array.isArray(value)) {
-      if (fieldName === 'amend-where-to-store-poison') {
+      if (fieldName === 'where-to-store-poison') {
         newValue = homeAddress?.concat('\n\n', storePoisonOtherAddress);
       }
-      if (fieldName === 'amend-where-to-use-poison') {
+      if (fieldName === 'where-to-use-poison') {
         newValue = homeAddress?.concat('\n\n', poisonUseOtherAddress);
       }
     } else {
       switch (fieldName) {
-        case 'amend-where-to-store-poison':
-          if (valueVar === 'amend-store-poison-home-address') {
+        case 'where-to-store-poison':
+          if (valueVar === 'store-poison-home-address-value') {
             newValue = homeAddress;
-          } else if (valueVar === 'amend-store-poison-other-address') {
+          } else if (valueVar === 'store-poison-other-address-value') {
             newValue = storePoisonOtherAddress;
           }
           break;
-        case 'amend-where-to-use-poison':
-          if (valueVar === 'amend-use-poison-home-address') {
+        case 'where-to-use-poison':
+          if (valueVar === 'use-poison-home-address') {
             newValue = homeAddress;
-          } else if (valueVar === 'amend-use-poison-other-address') {
+          } else if (valueVar === 'use-poison-other-address-value') {
             newValue = poisonUseOtherAddress;
           }
           break;

--- a/apps/epp-common/behaviours/modify-summary-change-links.js
+++ b/apps/epp-common/behaviours/modify-summary-change-links.js
@@ -18,6 +18,7 @@ const remapChangeLinks = (fields, mappings) => {
 };
 
 const precursorsSummaryStep = '/precursors-summary';
+const poisonsSummaryStep = '/poison-summary';
 
 const getChangeLinkUrl = (req, path) => {
   const application = req.sessionModel.get('applicationType');
@@ -41,6 +42,10 @@ module.exports = superclass =>
             {
               field: 'amend-display-precursor-title',
               changeLink: getChangeLinkUrl(req, precursorsSummaryStep)
+            },
+            {
+              field: 'display-poison-title',
+              changeLink: getChangeLinkUrl(req, poisonsSummaryStep)
             }
           ];
           section.fields = remapChangeLinks(section.fields, summaryMappings);

--- a/apps/epp-common/behaviours/parse-summary-precursors-poisons.js
+++ b/apps/epp-common/behaviours/parse-summary-precursors-poisons.js
@@ -17,7 +17,7 @@ module.exports = superclass =>
         'amend-display-precursor-title',
         'poison-use-other-address',
         'store-poison-other-address',
-        'amend-display-poison-title'
+        'display-poison-title'
       ];
       const locals = super.locals(req, res);
       locals.items = locals.items.map(item => {

--- a/apps/epp-replace/fields/index.js
+++ b/apps/epp-replace/fields/index.js
@@ -392,25 +392,25 @@ module.exports = {
       }
     ].concat(countries)
   },
-  'replace-why-need-poison': {
+  'why-need-poison': {
     mixin: 'textarea',
     validate: ['required', 'notUrl', textAreaDefaultLength],
     attributes: [{ attribute: 'rows', value: 5 }],
     labelClassName: 'govuk-label--s'
   },
-  'replace-how-much-poison': {
+  'how-much-poison': {
     mixin: 'input-text',
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
     className: ['govuk-input', 'govuk-input--width-10'],
     labelClassName: 'govuk-label--s'
   },
-  'replace-compound-or-salt': {
+  'compound-or-salt': {
     mixin: 'textarea',
     validate: ['required', 'notUrl', textAreaDefaultLength],
     attributes: [{ attribute: 'rows', value: 5 }],
     labelClassName: 'govuk-label--s'
   },
-  'replace-what-concentration-poison': {
+  'what-concentration-poison': {
     mixin: 'input-text',
     validate: [
       'required',
@@ -422,7 +422,7 @@ module.exports = {
     labelClassName: 'govuk-label--s',
     attributes: [{ suffix: '%' }]
   },
-  'replace-where-to-store-poison': {
+  'where-to-store-poison': {
     mixin: 'checkbox-group',
     validate: ['required'],
     legend: {
@@ -430,10 +430,10 @@ module.exports = {
     },
     options: [
       {
-        value: 'replace-store-poison-home-address'
+        value: 'store-poison-home-address-value'
       },
       {
-        value: 'replace-store-poison-other-address',
+        value: 'store-poison-other-address-value',
         toggle: 'store-poison-other-address',
         child: 'textarea'
       }
@@ -443,12 +443,12 @@ module.exports = {
     mixin: 'textarea',
     validate: ['required', textAreaDefaultLength, 'notUrl'],
     dependent: {
-      field: 'replace-where-to-store-poison',
-      value: 'replace-store-poison-other-address'
+      field: 'where-to-store-poison',
+      value: 'store-poison-other-address-value'
     },
     attributes: [{ attribute: 'rows', value: 5 }]
   },
-  'replace-where-to-use-poison': {
+  'where-to-use-poison': {
     mixin: 'checkbox-group',
     validate: ['required'],
     legend: {
@@ -456,10 +456,10 @@ module.exports = {
     },
     options: [
       {
-        value: 'replace-use-poison-home-address'
+        value: 'use-poison-home-address'
       },
       {
-        value: 'replace-use-poison-other-address',
+        value: 'use-poison-other-address-value',
         toggle: 'poison-use-other-address',
         child: 'textarea'
       }
@@ -469,8 +469,8 @@ module.exports = {
     mixin: 'textarea',
     validate: ['required', textAreaDefaultLength, 'notUrl'],
     dependent: {
-      field: 'replace-where-to-use-poison',
-      value: 'replace-use-poison-other-address'
+      field: 'where-to-use-poison',
+      value: 'use-poison-other-address-value'
     },
     attributes: [{ attribute: 'rows', value: 5 }]
   },

--- a/apps/epp-replace/fields/index.js
+++ b/apps/epp-replace/fields/index.js
@@ -4,7 +4,9 @@ const poisonsList = require('../../../utilities/constants/poisons.js');
 const countersignatoryYears = require('../../../utilities/constants/countersignatory-years.js');
 const {
   isValidUkDrivingLicenceNumber,
-  validInternationalPhoneNumber
+  validInternationalPhoneNumber,
+  textAreaDefaultLength,
+  isValidConcentrationValue
 } = require('../../../utilities/helpers');
 const countries = require('../../../utilities/constants/countries');
 const policeForces = require('../../../utilities/constants/police-forces.js');
@@ -388,6 +390,88 @@ module.exports = {
         label: 'fields.replace-home-country.options.none_selected'
       }
     ].concat(countries)
+  },
+  'replace-why-need-poison': {
+    mixin: 'textarea',
+    validate: ['required', 'notUrl', textAreaDefaultLength],
+    attributes: [{ attribute: 'rows', value: 5 }],
+    labelClassName: 'govuk-label--s'
+  },
+  'replace-how-much-poison': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
+    className: ['govuk-input', 'govuk-input--width-10'],
+    labelClassName: 'govuk-label--s'
+  },
+  'replace-compound-or-salt': {
+    mixin: 'textarea',
+    validate: ['required', 'notUrl', textAreaDefaultLength],
+    attributes: [{ attribute: 'rows', value: 5 }],
+    labelClassName: 'govuk-label--s'
+  },
+  'replace-what-concentration-poison': {
+    mixin: 'input-text',
+    validate: [
+      'required',
+      isValidConcentrationValue,
+      { type: 'maxlength', arguments: 250 },
+      'notUrl'
+    ],
+    className: ['govuk-input', 'govuk-input--width-5'],
+    labelClassName: 'govuk-label--s',
+    attributes: [{ suffix: '%' }]
+  },
+  'replace-where-to-store-poison': {
+    mixin: 'checkbox-group',
+    validate: ['required'],
+    legend: {
+      className: 'govuk-label--s'
+    },
+    options: [
+      {
+        value: 'replace-store-poison-home-address'
+      },
+      {
+        value: 'replace-store-poison-other-address',
+        toggle: 'store-poison-other-address',
+        child: 'textarea'
+      }
+    ]
+  },
+  'store-poison-other-address': {
+    mixin: 'textarea',
+    validate: ['required', textAreaDefaultLength, 'notUrl'],
+    dependent: {
+      field: 'replace-where-to-store-poison',
+      value: 'replace-store-poison-other-address'
+    },
+    attributes: [{ attribute: 'rows', value: 5 }]
+  },
+  'replace-where-to-use-poison': {
+    mixin: 'checkbox-group',
+    validate: ['required'],
+    legend: {
+      className: 'govuk-label--s'
+    },
+    options: [
+      {
+        value: 'replace-use-poison-home-address'
+      },
+      {
+        value: 'replace-use-poison-other-address',
+        toggle: 'poison-use-other-address',
+        child: 'textarea'
+      }
+    ]
+  },
+  'poison-use-other-address': {
+    mixin: 'textarea',
+    validate: ['required', textAreaDefaultLength, 'notUrl'],
+    dependent: {
+      field: 'replace-where-to-use-poison',
+      value: 'replace-use-poison-other-address'
+    },
+    attributes: [{ attribute: 'rows', value: 5 }]
   },
   'amend-declaration': {
     mixin: 'checkbox',

--- a/apps/epp-replace/fields/index.js
+++ b/apps/epp-replace/fields/index.js
@@ -159,7 +159,7 @@ module.exports = {
     className: ['govuk-input'],
     labelClassName: 'govuk-label--m'
   },
-  'replace-poison': {
+  'poison-field': {
     mixin: 'select',
     validate: ['required'],
     labelClassName: 'visuallyhidden',
@@ -167,7 +167,7 @@ module.exports = {
     options: [
       {
         value: '',
-        label: 'fields.replace-poison.options.none_selected'
+        label: 'fields.poison-field.options.none_selected'
       }
     ].concat(poisonsList)
   },

--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -12,7 +12,7 @@ const SaveHomeAddress = require('../epp-common/behaviours/save-home-address');
 const InitiatePaymentRequest = require('../epp-common/behaviours/initiate-payment-request');
 const GetPaymentInfo = require('../epp-common/behaviours/get-payment-info');
 const AfterDateOfBirth = require('../epp-common/behaviours/after-date-validator');
-
+const RenderPoisonDetails = require('../epp-common/behaviours/render-poison-detail');
 
 // TODO: Use DeleteRedundantDocuments behaviour similar to amend flow to
 // remove the uploaded files when dependent option changes
@@ -266,15 +266,27 @@ module.exports = {
     },
     '/select-poisons': {
       fields: ['replace-poison'],
-      locals: { captionHeading: 'Section 20 of 26' },
-      next: '/section-seventeen-poison'
+      next: '/poison-details',
+      locals: { captionHeading: 'Section 20 of 26' }
     },
-    '/section-seventeen-poison': {
-      fields: ['replace-poison-details'],
-      next: '/section-seventeen-summary'
+    '/poison-details': {
+      behaviours: [RenderPoisonDetails('replace-poison')],
+      fields: [
+        'replace-why-need-poison',
+        'replace-how-much-poison',
+        'replace-compound-or-salt',
+        'replace-what-concentration-poison',
+        'replace-where-to-store-poison',
+        'replace-where-to-use-poison',
+        'store-poison-other-address',
+        'poison-use-other-address'
+      ],
+      next: '/poisons-summary',
+      locals: { captionHeading: 'Section 20 of 26' }
     },
-    '/section-seventeen-summary': {
-      next: '/countersignatory-details'
+    '/poisons-summary': {
+      next: '/countersignatory-details',
+      locals: { captionHeading: 'Section 20 of 26' }
     },
     '/countersignatory-details': {
       fields: [

--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -292,12 +292,12 @@ module.exports = {
     '/poison-details': {
       behaviours: [RenderPoisonDetails('replace-poison')],
       fields: [
-        'replace-why-need-poison',
-        'replace-how-much-poison',
-        'replace-compound-or-salt',
-        'replace-what-concentration-poison',
-        'replace-where-to-store-poison',
-        'replace-where-to-use-poison',
+        'why-need-poison',
+        'how-much-poison',
+        'compound-or-salt',
+        'what-concentration-poison',
+        'where-to-store-poison',
+        'where-to-use-poison',
         'store-poison-other-address',
         'poison-use-other-address'
       ],

--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -285,12 +285,12 @@ module.exports = {
       next: '/select-poisons'
     },
     '/select-poisons': {
-      fields: ['replace-poison'],
+      fields: ['poison-field'],
       next: '/poison-details',
       locals: { captionHeading: 'Section 20 of 26' }
     },
     '/poison-details': {
-      behaviours: [RenderPoisonDetails('replace-poison')],
+      behaviours: [RenderPoisonDetails('poison-field')],
       fields: [
         'why-need-poison',
         'how-much-poison',

--- a/apps/epp-replace/sections/summary-data-sections.js
+++ b/apps/epp-replace/sections/summary-data-sections.js
@@ -290,7 +290,7 @@ module.exports = {
     steps: [
       {
         step: '/select-poisons',
-        field: 'replace-poison'
+        field: 'poison-field'
       }
     ]
   },

--- a/apps/epp-replace/translations/src/en/fields.json
+++ b/apps/epp-replace/translations/src/en/fields.json
@@ -94,33 +94,33 @@
       "none_selected": "Select poison"
     }
   },
-  "replace-why-need-poison": {
+  "why-need-poison": {
     "label": "{{values.whyNeedPoisonLabel}}",
     "hint": "Detailed answers mean we can process your application faster",
     "summary-heading": "{{values.whyNeedPoisonLabel}}"
   },
-  "replace-how-much-poison": {
+  "how-much-poison": {
     "label": "How much do you wish to acquire at any one time within a 6-month period?",
     "hint": "Enter the amount and the unit. For example, 10 litres",
      "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
   },
-  "replace-compound-or-salt": {
+  "compound-or-salt": {
     "label": "Specific compound or salt",
     "summary-heading": "Specific compound or salt"
   },
-  "replace-what-concentration-poison": {
+  "what-concentration-poison": {
     "label": "What concentration % w/w of the substance do you need?",
      "summary-heading": "What concentration % w/w of the substance do you need?"
   },
-  "replace-where-to-store-poison": {
+  "where-to-store-poison": {
     "legend": "{{values.whereToStorePoisonLegend}}",
     "summary-heading": "{{values.whereToStorePoisonLegend}}",
     "hint": "This must be in the UK",
     "options": {
-      "replace-store-poison-home-address": {
+      "store-poison-home-address-value": {
         "label": "{{values.homeAddressInline}}"
       },
-      "replace-store-poison-other-address": {
+      "store-poison-other-address-value": {
         "label": "Other address"
       }
     }
@@ -130,15 +130,15 @@
     "hint": "Enter a UK address",
     "summary-heading": "{{values.storePoisonOtherAddressLabel}}"
   },
-  "replace-where-to-use-poison": {
+  "where-to-use-poison": {
     "legend": "{{values.whereToUsePoisonLegend}}",
     "hint": "This must be in the UK",
     "summary-heading": "{{values.whereToUsePoisonLegend}}",
     "options": {
-      "replace-use-poison-home-address": {
+      "use-poison-home-address": {
         "label": "{{values.homeAddressInline}}"
       },
-      "replace-use-poison-other-address": {
+      "use-poison-other-address-value": {
         "label": "Other address"
       }
     }

--- a/apps/epp-replace/translations/src/en/fields.json
+++ b/apps/epp-replace/translations/src/en/fields.json
@@ -59,6 +59,33 @@
       }
     }
   },
+      "replace-new-address-1": {
+        "label": "Address line 1"
+      },
+      "replace-new-address-2": {
+        "label": "Address line 2 (optional)"
+      },
+      "replace-new-town-or-city": {
+        "label": "Town or city"
+      },
+      "replace-new-county": {
+        "label": "County, state, province (optional)"
+      },
+      "replace-new-postcode": {
+        "label": "Postcode (optional)",
+        "hint": "Postcode is optional if your address is outside the UK"
+      },
+      "replace-new-country": {
+        "label": "Country of address",
+        "hint": "Select a country from the list",
+        "options": {
+          "none_selected": "Select"
+        }
+      },
+      "replace-new-date-moved-to-address": {
+          "legend": "When did you move to this address?",
+          "hint": " For example, 30 09 1969"
+      },
   "replace-licence": {
     "legend": "Why do you need a replacement licence?",
     "options": {

--- a/apps/epp-replace/translations/src/en/fields.json
+++ b/apps/epp-replace/translations/src/en/fields.json
@@ -1,14 +1,14 @@
 {
-    "replace-licence-number": {
-        "label": "Enter your licence number (optional)",
-        "hint": "For example 95/W/000000/2024"
-    },
-    "replace-title": {
-        "label": "Title",
-        "options": {
-          "none_selected": "Select"
-        }
-      },
+  "replace-licence-number": {
+    "label": "Enter your licence number (optional)",
+    "hint": "For example 95/W/000000/2024"
+  },
+  "replace-title": {
+    "label": "Title",
+    "options": {
+      "none_selected": "Select"
+    }
+  },
       "replace-new-name-title": {
         "label": "Title",
         "options": {
@@ -28,186 +28,240 @@
         "legend": "What date did you change your name?",
         "hint": "For example, 30 09 2014"
       },
-      "replace-first-name": {
-        "label": "First name"
+  "replace-first-name": {
+    "label": "First name"
+  },
+  "replace-middle-name": {
+    "label": "Middle names (optional)"
+  },
+  "replace-last-name": {
+    "label": "Last name"
+  },
+  "replace-police-report": {
+    "legend": "Have you reported the theft to the police?",
+    "options": {
+      "yes": {
+        "label": "Yes"
       },
-      "replace-middle-name": {
-        "label": "Middle names (optional)"
-      },
-      "replace-last-name": {
-        "label": "Last name"
-      },
-      "replace-police-report": {
-        "legend": "Have you reported the theft to the police?",
-        "options": {
-          "yes": {
-            "label": "Yes"
-          },
-          "no": {
-            "label": "No"
-          }
-        }
-      },
-      "replace-licence": {
-        "legend": "Why do you need a replacement licence?",
-        "options": {
-          "replace-licence-stolen": {
-            "label": "Licence was stolen"
-          },
-          "replace-licence-lost": {
-            "label": "Licence is lost"
-          },
-          "replace-licence-damaged": {
-            "label": "Licence is damaged"
-          },
-          "replace-licence-destroyed": {
-            "label": "Licence is destroyed"
-          }
-        }
-      },
-      "replace-is-details-changed": {
-        "legend": "Have any of your details changed since the licence was issued?",
-        "hint": "Includes the name, address and substances recorded on the licence",
-        "options": {
-          "yes": {
-            "label": "Yes"
-          },
-          "no": {
-            "label": "No"
-          }
-        }
-      },
-      "replace-countersignatory-title":{
-        "label": "Title",
-        "options": {
-          "none_selected": "Select"
-        }
-      },
-      "replace-countersignatory-firstname":{
-        "label": "First name"
-      },
-      "replace-countersignatory-middlename":{
-        "label": "Middle names (optional)"
-      },
-      "replace-countersignatory-lastname":{
-        "label": "Last name"
-      },
-      "replace-countersignatory-years": {
-        "label": "How many years have you known your countersignatory?",
-        "hint": "They must have known you for at least 2 years",
-        "options": {
-          "none_selected": "Select"
-        }
-      },
-      "replace-countersignatory-howyouknow":{
-        "label": "How do you know your countersignatory?"
-      },
-      "replace-countersignatory-occupation":{
-        "label": "What is your countersignatory’s occupation?"
-      },
-      "replace-countersignatory-address-1": {
-        "label": "Address line 1"
-      },
-      "replace-countersignatory-address-2": {
-        "label": "Address line 2 (optional)"
-      },
-      "replace-countersignatory-town-or-city": {
-        "label": "Town or city"
-      },
-      "replace-countersignatory-postcode": {
-        "label": "Postcode"
-      },
-      "replace-countersignatory-phone-number": {
-        "label": "Contact phone number",
-        "hint": "For international numbers, include the country code"
-      },
-      "replace-countersignatory-email": {
-        "label": "Email address"
-      },
-      "replace-poison": {
-        "hint": "Select a poison",
-          "options":{
-            "none_selected": "Select poison"
-        }
-      },
-      "replace-countersignatory-Id-type": {
-        "legend": "What is your countersignatory’s identity document?",
-        "hint": "You only need to provide a document number.",
-        "options": {
-          "UK-passport": {
-            "label": "British passport"
-          },
-          "EU-passport": {
-            "label": "Passport from the EU, Switzerland, Norway, Iceland or Liechtenstein"
-          },
-          "Uk-driving-licence": {
-            "label": "UK driving licence",
-            "hint": "Must be a photocard licence."
-          }
-        }
-      },
-      "replace-countersignatory-UK-passport-number": {
-        "label": "What is your passport number?",
-        "hint" : "For example, 120897A"    
-      },
-      "replace-countersignatory-EU-passport-number": {
-        "label": "What is your passport number?",
-        "hint" : "For example, 120897A"  
-      },
-      "replace-countersignatory-Uk-driving-licence-number": {
-        "label": "What is your driving licence number?",
-        "hint" : "On section 5 of your licence, for example MORGA657054SM9IJ"    
-      },
-      "replace-date-of-birth": {
-        "hint": " For example, 30 09 1969",
-        "label": "Date of birth"
-      },
-      "replace-which-document-type": {
-        "legend": "Which identity document do you want to use?",
-        "hint": "If your licence is granted, you will need to show this document when buying the substances",
-        "options": {
-          "UK-passport": {
-            "label": "British passport"
-          },
-          "EU-passport": {
-            "label": "Passport from the EU, Switzerland, Norway, Iceland or Liechtenstein"
-          },
-          "Uk-driving-licence": {
-            "label": "UK driving licence",
-            "hint": "Must be a photocard licence."
-          }
-        }
-      },
-      "replace-UK-passport-number": {
-        "label": "What is your passport number?",
-        "hint" : "For example, 120897A"    
-      },
-      "replace-EU-passport-number": {
-        "label": "What is your passport number?",
-        "hint" : "For example, 120897A"  
-      },
-      "replace-Uk-driving-licence-number": {
-        "label": "What is your driving licence number?",
-        "hint" : "On section 5 of your licence, for example MORGA657054SM9IJ"    
-      },
-      "replace-phone-number": {
-        "label": "Contact phone number",
-        "hint": "For international numbers, include the country code"
-    },
-    "replace-email": {
-        "label": "Email address",
-        "hint": "Where we will contact you about the outcome of your application"
-    },
-    "replace-police-force": {
-      "label": "Which police force did you report this to?",
-      "hint": "Select a police force from the list",
-      "options": {
-        "none_selected": "Select"
+      "no": {
+        "label": "No"
       }
-    },
-    "replace-crime-number": {
-      "label": "Crime number"
-    },
+    }
+  },
+  "replace-licence": {
+    "legend": "Why do you need a replacement licence?",
+    "options": {
+      "replace-licence-stolen": {
+        "label": "Licence was stolen"
+      },
+      "replace-licence-lost": {
+        "label": "Licence is lost"
+      },
+      "replace-licence-damaged": {
+        "label": "Licence is damaged"
+      },
+      "replace-licence-destroyed": {
+        "label": "Licence is destroyed"
+      }
+    }
+  },
+  "replace-is-details-changed": {
+    "legend": "Have any of your details changed since the licence was issued?",
+    "hint": "Includes the name, address and substances recorded on the licence",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "replace-poison": {
+    "hint": "Select a poison",
+    "options": {
+      "none_selected": "Select poison"
+    }
+  },
+  "replace-why-need-poison": {
+    "label": "{{values.whyNeedPoisonLabel}}",
+    "hint": "Detailed answers mean we can process your application faster",
+    "summary-heading": "{{values.whyNeedPoisonLabel}}"
+  },
+  "replace-how-much-poison": {
+    "label": "How much do you wish to acquire at any one time within a 6-month period?",
+    "hint": "Enter the amount and the unit. For example, 10 litres",
+     "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
+  },
+  "replace-compound-or-salt": {
+    "label": "Specific compound or salt",
+    "summary-heading": "Specific compound or salt"
+  },
+  "replace-what-concentration-poison": {
+    "label": "What concentration % w/w of the substance do you need?",
+     "summary-heading": "What concentration % w/w of the substance do you need?"
+  },
+  "replace-where-to-store-poison": {
+    "legend": "{{values.whereToStorePoisonLegend}}",
+    "summary-heading": "{{values.whereToStorePoisonLegend}}",
+    "hint": "This must be in the UK",
+    "options": {
+      "replace-store-poison-home-address": {
+        "label": "{{values.homeAddressInline}}"
+      },
+      "replace-store-poison-other-address": {
+        "label": "Other address"
+      }
+    }
+  },
+  "store-poison-other-address": {
+    "label": "{{values.storePoisonOtherAddressLabel}}",
+    "hint": "Enter a UK address",
+    "summary-heading": "{{values.storePoisonOtherAddressLabel}}"
+  },
+  "replace-where-to-use-poison": {
+    "legend": "{{values.whereToUsePoisonLegend}}",
+    "hint": "This must be in the UK",
+    "summary-heading": "{{values.whereToUsePoisonLegend}}",
+    "options": {
+      "replace-use-poison-home-address": {
+        "label": "{{values.homeAddressInline}}"
+      },
+      "replace-use-poison-other-address": {
+        "label": "Other address"
+      }
+    }
+  },
+  "poison-use-other-address": {
+    "label": "{{values.usePoisonOtherAddressLabel}}",
+    "hint": "Enter a UK address",
+    "summary-heading": "{{values.usePoisonOtherAddressLabel}}"
+  },
+  "replace-countersignatory-title": {
+    "label": "Title",
+    "options": {
+      "none_selected": "Select"
+    }
+  },
+  "replace-countersignatory-firstname": {
+    "label": "First name"
+  },
+  "replace-countersignatory-middlename": {
+    "label": "Middle names (optional)"
+  },
+  "replace-countersignatory-lastname": {
+    "label": "Last name"
+  },
+  "replace-countersignatory-years": {
+    "label": "How many years have you known your countersignatory?",
+    "hint": "They must have known you for at least 2 years",
+    "options": {
+      "none_selected": "Select"
+    }
+  },
+  "replace-countersignatory-howyouknow": {
+    "label": "How do you know your countersignatory?"
+  },
+  "replace-countersignatory-occupation": {
+    "label": "What is your countersignatory’s occupation?"
+  },
+  "replace-countersignatory-address-1": {
+    "label": "Address line 1"
+  },
+  "replace-countersignatory-address-2": {
+    "label": "Address line 2 (optional)"
+  },
+  "replace-countersignatory-town-or-city": {
+    "label": "Town or city"
+  },
+  "replace-countersignatory-postcode": {
+    "label": "Postcode"
+  },
+  "replace-countersignatory-phone-number": {
+    "label": "Contact phone number",
+    "hint": "For international numbers, include the country code"
+  },
+  "replace-countersignatory-email": {
+    "label": "Email address"
+  },
+  "replace-countersignatory-Id-type": {
+    "legend": "What is your countersignatory’s identity document?",
+    "hint": "You only need to provide a document number.",
+    "options": {
+      "UK-passport": {
+        "label": "British passport"
+      },
+      "EU-passport": {
+        "label": "Passport from the EU, Switzerland, Norway, Iceland or Liechtenstein"
+      },
+      "Uk-driving-licence": {
+        "label": "UK driving licence",
+        "hint": "Must be a photocard licence."
+      }
+    }
+  },
+  "replace-countersignatory-UK-passport-number": {
+    "label": "What is your passport number?",
+    "hint": "For example, 120897A"
+  },
+  "replace-countersignatory-EU-passport-number": {
+    "label": "What is your passport number?",
+    "hint": "For example, 120897A"
+  },
+  "replace-countersignatory-Uk-driving-licence-number": {
+    "label": "What is your driving licence number?",
+    "hint": "On section 5 of your licence, for example MORGA657054SM9IJ"
+  },
+  "replace-date-of-birth": {
+    "hint": " For example, 30 09 1969",
+    "label": "Date of birth"
+  },
+  "replace-which-document-type": {
+    "legend": "Which identity document do you want to use?",
+    "hint": "If your licence is granted, you will need to show this document when buying the substances",
+    "options": {
+      "UK-passport": {
+        "label": "British passport"
+      },
+      "EU-passport": {
+        "label": "Passport from the EU, Switzerland, Norway, Iceland or Liechtenstein"
+      },
+      "Uk-driving-licence": {
+        "label": "UK driving licence",
+        "hint": "Must be a photocard licence."
+      }
+    }
+  },
+  "replace-UK-passport-number": {
+    "label": "What is your passport number?",
+    "hint": "For example, 120897A"
+  },
+  "replace-EU-passport-number": {
+    "label": "What is your passport number?",
+    "hint": "For example, 120897A"
+  },
+  "replace-Uk-driving-licence-number": {
+    "label": "What is your driving licence number?",
+    "hint": "On section 5 of your licence, for example MORGA657054SM9IJ"
+  },
+  "replace-phone-number": {
+    "label": "Contact phone number",
+    "hint": "For international numbers, include the country code"
+  },
+  "replace-email": {
+    "label": "Email address",
+    "hint": "Where we will contact you about the outcome of your application"
+  },
+  "replace-police-force": {
+    "label": "Which police force did you report this to?",
+    "hint": "Select a police force from the list",
+    "options": {
+      "none_selected": "Select"
+    }
+  },
+  "replace-crime-number": {
+    "label": "Crime number"
+  },
   "replace-home-address-1": {
     "label": "Address line 1"
   },

--- a/apps/epp-replace/translations/src/en/fields.json
+++ b/apps/epp-replace/translations/src/en/fields.json
@@ -115,7 +115,7 @@
       }
     }
   },
-  "replace-poison": {
+  "poison-field": {
     "hint": "Select a poison",
     "options": {
       "none_selected": "Select poison"

--- a/apps/epp-replace/translations/src/en/pages.json
+++ b/apps/epp-replace/translations/src/en/pages.json
@@ -100,6 +100,9 @@
     "header": "You must report the theft to the police",
     "p1": "If you want to apply for a replacement licence, you need to report the theft to the police. They will provide you with a crime reference number, which you must use to complete this form."
   },
+  "poison-details":{
+    "header": "{{values.replace-poison}}"
+  },
   "countersignatory-details": {
     "header": "Countersignatory details",
     "description": "Your countersignatory must not be a parent or relative, unless you are under 18. If you are under 18, your countersignatory must be your parent or legal guardian."

--- a/apps/epp-replace/translations/src/en/pages.json
+++ b/apps/epp-replace/translations/src/en/pages.json
@@ -109,7 +109,7 @@
     "p1": "If you want to apply for a replacement licence, you need to report the theft to the police. They will provide you with a crime reference number, which you must use to complete this form."
   },
   "poison-details":{
-    "header": "{{values.replace-poison}}"
+    "header": "{{values.poison-field}}"
   },
   "countersignatory-details": {
     "header": "Countersignatory details",
@@ -285,7 +285,7 @@
       "replace-countersignatory-phone-number": {
         "label": "Phone number"
       },
-      "replace-poison": {
+      "poison-field": {
         "label": "Poisons"
       },
       "replace-countersignatory-Id-type": {

--- a/apps/epp-replace/translations/src/en/validation.json
+++ b/apps/epp-replace/translations/src/en/validation.json
@@ -35,31 +35,31 @@
 "replace-licence": {
   "required": "Select why you need a replacement licence"
 },
-"replace-why-need-poison": {
+"why-need-poison": {
     "required": "Explain why you need this poison",
     "textAreaDefaultLength": "Reason why you need this poison must be less than 2,000 characters",
     "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
-  "replace-how-much-poison": {
+  "how-much-poison": {
     "required": "Enter how much of poison you wish to acquire at any one time",
     "maxlength": "Quantity of the explosive precursor you wish to acquire must be 250 characters or less",
     "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
-  "replace-compound-or-salt": {
+  "compound-or-salt": {
      "required": "Enter the specific compound or salt",
      "textAreaDefaultLength": " Specific compound or salt must be less than 2,000 characters",
      "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
-  "replace-what-concentration-poison": {
+  "what-concentration-poison": {
     "required": "Enter what concentration % w/w you need",
     "isValidConcentrationValue" : "Concentration % w/w must only include numbers or special characters",
     "maxlength": "Concentration % w/w must be 250 characters or less",
     "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
-  "replace-where-to-store-poison": {
+  "where-to-store-poison": {
     "required": "Select where you will store the poison"
   },
-  "replace-where-to-use-poison": {
+  "where-to-use-poison": {
     "required": "Select where you will use the poison"
   },
   "store-poison-other-address": {

--- a/apps/epp-replace/translations/src/en/validation.json
+++ b/apps/epp-replace/translations/src/en/validation.json
@@ -35,6 +35,43 @@
 "replace-licence": {
   "required": "Select why you need a replacement licence"
 },
+"replace-why-need-poison": {
+    "required": "Explain why you need this poison",
+    "textAreaDefaultLength": "Reason why you need this poison must be less than 2,000 characters",
+    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "replace-how-much-poison": {
+    "required": "Enter how much of poison you wish to acquire at any one time",
+    "maxlength": "Quantity of the explosive precursor you wish to acquire must be 250 characters or less",
+    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "replace-compound-or-salt": {
+     "required": "Enter the specific compound or salt",
+     "textAreaDefaultLength": " Specific compound or salt must be less than 2,000 characters",
+     "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "replace-what-concentration-poison": {
+    "required": "Enter what concentration % w/w you need",
+    "isValidConcentrationValue" : "Concentration % w/w must only include numbers or special characters",
+    "maxlength": "Concentration % w/w must be 250 characters or less",
+    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "replace-where-to-store-poison": {
+    "required": "Select where you will store the poison"
+  },
+  "replace-where-to-use-poison": {
+    "required": "Select where you will use the poison"
+  },
+  "store-poison-other-address": {
+    "required": "Enter the address where you will store the poison",
+    "textAreaDefaultLength": "Storage address must be 2,000 characters or less",
+    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "poison-use-other-address": {
+    "required": "Enter the address where you will use the poison",
+    "textAreaDefaultLength": "Usage address must be 2,000 characters or less",
+    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
 "replace-countersignatory-title": {
     "required": "Select your countersignatory's title"
   },

--- a/apps/epp-replace/translations/src/en/validation.json
+++ b/apps/epp-replace/translations/src/en/validation.json
@@ -132,7 +132,7 @@
     "required": "Enter your countersignatory's email address",
     "email": "Enter a real email address"
   },
-  "replace-poison": {
+  "poison-field": {
     "required": "Select a poison"
   },
 "replace-countersignatory-Id-type": {

--- a/test/unit/behaviours/aggregator-save-update-precursors-poisons.spec.js
+++ b/test/unit/behaviours/aggregator-save-update-precursors-poisons.spec.js
@@ -157,8 +157,8 @@ describe('Behaviour', () => {
   });
 
   describe('parsePoisonField', () => {
-    it('should parse array field correctly when field is amend-where-to-store-poison', () => {
-      const field = 'amend-where-to-store-poison';
+    it('should parse array field correctly when field is where-to-store-poison', () => {
+      const field = 'where-to-store-poison';
       const value = ['value1', 'value2'];
       req.sessionModel.get.withArgs('homeAddressInline').returns('homeAddress');
       req.sessionModel.get
@@ -170,8 +170,8 @@ describe('Behaviour', () => {
       expect(result).to.equal('homeAddress\n\notherAddress');
     });
 
-    it('should parse array field correctly when field is amend-where-to-use-poison', () => {
-      const field = 'amend-where-to-use-poison';
+    it('should parse array field correctly when field is where-to-use-poison', () => {
+      const field = 'where-to-use-poison';
       const value = ['value1', 'value2'];
       req.sessionModel.get.withArgs('homeAddressInline').returns('homeAddress');
       req.sessionModel.get
@@ -185,11 +185,11 @@ describe('Behaviour', () => {
 
     it(
       'should parse string field correctly when field is ' +
-        'amend-where-to-store-poison and value is ' +
-        'amend-store-poison-home-address',
+        'where-to-store-poison and value is ' +
+        'store-poison-home-address-value',
       () => {
-        const field = 'amend-where-to-store-poison';
-        const value = 'amend-store-poison-home-address';
+        const field = 'where-to-store-poison';
+        const value = 'store-poison-home-address-value';
         req.sessionModel.get
           .withArgs('homeAddressInline')
           .returns('homeAddress');
@@ -202,11 +202,11 @@ describe('Behaviour', () => {
 
     it(
       'should parse string field correctly when field is ' +
-        'amend-where-to-store-poison and value is ' +
-        'amend-store-poison-other-address',
+        'where-to-store-poison and value is ' +
+        'store-poison-other-address-value',
       () => {
-        const field = 'amend-where-to-store-poison';
-        const value = 'amend-store-poison-other-address';
+        const field = 'where-to-store-poison';
+        const value = 'store-poison-other-address-value';
         req.sessionModel.get
           .withArgs('store-poison-other-address')
           .returns('otherAddress');
@@ -219,11 +219,11 @@ describe('Behaviour', () => {
 
     it(
       'should parse string field correctly when field is ' +
-        'amend-where-to-use-poison and ' +
-        'value is amend-use-poison-home-address',
+        'where-to-use-poison and ' +
+        'value is use-poison-home-address',
       () => {
-        const field = 'amend-where-to-use-poison';
-        const value = 'amend-use-poison-home-address';
+        const field = 'where-to-use-poison';
+        const value = 'use-poison-home-address';
         req.sessionModel.get
           .withArgs('homeAddressInline')
           .returns('homeAddress');
@@ -236,11 +236,11 @@ describe('Behaviour', () => {
 
     it(
       'should parse string field correctly when field is ' +
-        'amend-where-to-use-poison and value is ' +
-        'amend-use-poison-other-address',
+        'where-to-use-poison and value is ' +
+        'use-poison-other-address-value',
       () => {
-        const field = 'amend-where-to-use-poison';
-        const value = 'amend-use-poison-other-address';
+        const field = 'where-to-use-poison';
+        const value = 'use-poison-other-address-value';
         req.sessionModel.get
           .withArgs('poison-use-other-address')
           .returns('otherAddress');


### PR DESCRIPTION
## What? 
Create poisons details page for replace journey as per jira ticket [EPP-205](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-205)
## Why? 
to allow user to provide details about the selected poison
## How? 

- add step in index.js and configured RenderPoisonDetails behaviour
- add fields in : fields/index.js, fields.json, pages.json, validations.json 

## Testing?
manual
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
