### PR TITLE
EPP-200 Replace select precursor

### DIFF
--- a/apps/epp-amend/fields/index.js
+++ b/apps/epp-amend/fields/index.js
@@ -293,7 +293,7 @@ module.exports = {
     options: ['yes', 'no'],
     validate: 'required'
   },
-  'amend-precursor-field': {
+  'precursor-field': {
     mixin: 'select',
     validate: ['required'],
     labelClassName: ['govuk-label--m', 'visuallyhidden'],
@@ -301,7 +301,7 @@ module.exports = {
     options: [
       {
         value: '',
-        label: 'fields.amend-precursor-field.options.none_selected'
+        label: 'fields.precursor-field.options.none_selected'
       }
     ].concat(precursorList)
   },

--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -289,13 +289,13 @@ module.exports = {
       locals: { captionHeading: 'Section 14 of 23' }
     },
     '/select-precursor': {
-      fields: ['amend-precursor-field'],
+      fields: ['precursor-field'],
       continueOnEdit: true,
       locals: { captionHeading: 'Section 15 of 23' },
       next: '/precursor-details'
     },
     '/precursor-details': {
-      behaviours: [RenderPrecursorDetails('amend-precursor-field')],
+      behaviours: [RenderPrecursorDetails('precursor-field')],
       fields: [
         'amend-why-need-precursor',
         'amend-how-much-precursor',
@@ -319,7 +319,7 @@ module.exports = {
         'amend-where-to-store-precursor',
         'amend-where-to-use-precursor'
       ],
-      titleField: ['amend-precursor-field'],
+      titleField: ['precursor-field'],
       addStep: 'select-precursor',
       addAnotherLinkText: 'explosives precursors',
       continueOnEdit: false,

--- a/apps/epp-amend/translations/src/en/fields.json
+++ b/apps/epp-amend/translations/src/en/fields.json
@@ -158,7 +158,7 @@
       }
     }
   },
-  "amend-precursor-field": {
+  "precursor-field": {
     "hint": "Select an explosives precursor",
     "options":{
       "none_selected": "Select"

--- a/apps/epp-amend/translations/src/en/pages.json
+++ b/apps/epp-amend/translations/src/en/pages.json
@@ -133,7 +133,7 @@
     "p3": "If you have any questions, contact"
   },
   "precursor-details":{
-    "header": "{{values.amend-precursor-field}}"
+    "header": "{{values.precursor-field}}"
   },
   "precursors-summary": {
     "header": "Poisons on your licence"
@@ -313,7 +313,7 @@
       "amend-proof-address":{
          "label": "Proof of address attachment"
       },
-      "amend-precursor-field": {
+      "precursor-field": {
          "label": "Explosives precursors"
       },
       "amend-display-precursor-title": {

--- a/apps/epp-amend/translations/src/en/validation.json
+++ b/apps/epp-amend/translations/src/en/validation.json
@@ -166,7 +166,7 @@
     "amend-change-substances-options": {
       "required" : "Select if you need to amend the substances on your licence"
     },
-    "amend-precursor-field": {
+    "precursor-field": {
       "required" : "Select an explosive precursor"
     },
   "amend-regulated-explosives-precursors": {

--- a/apps/epp-common/behaviours/aggregator-save-update-precursors-poisons.js
+++ b/apps/epp-common/behaviours/aggregator-save-update-precursors-poisons.js
@@ -57,7 +57,7 @@ module.exports = superclass => class extends superclass {
 
 
       if (!isTitleField && itemTitle.length === 0) {
-        itemTitle.push(getSubstanceShortLabel(req.sessionModel.get('amend-precursor-field'), SUBSTANCES.PRECURSOR));
+        itemTitle.push(getSubstanceShortLabel(req.sessionModel.get('precursor-field'), SUBSTANCES.PRECURSOR));
       }
 
       fields.push({

--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -732,14 +732,14 @@ module.exports = {
     ].concat(countries),
     validate: ['required']
   },
-  'amend-precursor-field': {
+  'precursor-field': {
     mixin: 'select',
     validate: ['required'],
     labelClassName: ['govuk-label--m', 'visuallyhidden'],
     options: [
       {
         value: '',
-        label: 'fields.amend-precursor-field.options.none_selected'
+        label: 'fields.precursor-field.options.none_selected'
       }
     ].concat(precursorList)
   }

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -565,9 +565,6 @@ module.exports = {
       }
     },
     '/select-precursor': {
-      // Conscious decision to use the same field as amend
-      // TODO: rename to a common field if the functionality
-      // works as expected
       fields: ['precursor-field'],
       next: '/precursor-details',
       locals: {

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -568,7 +568,7 @@ module.exports = {
       // Conscious decision to use the same field as amend
       // TODO: rename to a common field if the functionality
       // works as expected
-      fields: ['amend-precursor-field'],
+      fields: ['precursor-field'],
       next: '/precursor-details',
       locals: {
         sectionNo: {

--- a/apps/epp-new/translations/src/en/fields.json
+++ b/apps/epp-new/translations/src/en/fields.json
@@ -427,7 +427,7 @@
       "none_selected": "Select"
     }
   },
-  "amend-precursor-field": {
+  "precursor-field": {
     "hint": "Select an explosives precursor",
     "options":{
       "none_selected": "Select"

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -368,7 +368,7 @@
   "new-renew-doctor-country": {
     "required": "Select your doctor's country of address"
   },
-  "amend-precursor-field": {
+  "precursor-field": {
     "required" : "Select an explosive precursor"
   }
 }

--- a/apps/epp-replace/fields/index.js
+++ b/apps/epp-replace/fields/index.js
@@ -431,15 +431,15 @@ module.exports = {
     options: ['yes', 'no'],
     validate: 'required'
   },
-'precursor-field': {
+  'precursor-field': {
     mixin: 'select',
     validate: ['required'],
     labelClassName: ['govuk-label--m', 'visuallyhidden'],
     options: [
-        {
-            value: '',
-            label: 'fields.precursor-field.options.none_selected'
-        }
+      {
+        value: '',
+        label: 'fields.precursor-field.options.none_selected'
+      }
     ].concat(precursorList)
-}
+  }
 };

--- a/apps/epp-replace/fields/index.js
+++ b/apps/epp-replace/fields/index.js
@@ -8,6 +8,7 @@ const {
 } = require('../../../utilities/helpers');
 const countries = require('../../../utilities/constants/countries');
 const policeForces = require('../../../utilities/constants/police-forces.js');
+const precursorList = require('../../../utilities/constants/explosive-precursors');
 
 module.exports = {
   'replace-licence-number': {
@@ -420,5 +421,16 @@ module.exports = {
     mixin: 'input-date',
     legend: { className: 'govuk-fieldset__legend--m' },
     validate: ['required', 'date', 'before']
-  })
+  }),
+  'precursor-field': {
+    mixin: 'select',
+    validate: ['required'],
+    labelClassName: ['govuk-label--m', 'visuallyhidden'],
+    options: [
+      {
+        value: '',
+        label: 'fields.precursor-field.options.none_selected'
+      }
+    ].concat(precursorList)
+  }
 };

--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -241,26 +241,21 @@ module.exports = {
       ],
       fields: ['file-upload'],
       locals: { captionHeading: 'Section 15 of 26' },
-      next: '/section-sixteen'
+      next: '/change-substances'
     },
-    '/section-sixteen': {
-      fields: ['replace-explosive-precusor-type'],
-      // fields: [
-      //   'replace-countersignatory-address-1',
-      //   'replace-countersignatory-address-2',
-      //   'replace-countersignatory-town-or-city',
-      //   'replace-countersignatory-postcode'
-      // ],
-      next: '/section-sixteen-type'
+    '/change-substances': {
+      next: '/explosives-precursors'
     },
-    '/section-sixteen-type': {
-      fields: ['replace-explosive-precusor-details'],
-      next: '/section-sixteen-summary'
+    '/explosives-precursors': {
+      next: '/select-precursor'
     },
-    '/section-sixteen-summary': {
-      next: '/section-seventeen'
+    '/select-precursor': {
+      fields: ['precursor-field'],
+      continueOnEdit: true,
+      locals: { captionHeading: 'Section 18 of 26' },
+      next: '/precursor-details'
     },
-    '/section-seventeen': {
+    '/precursor-details': {
       fields: [],
       next: '/select-poisons'
     },

--- a/apps/epp-replace/translations/src/en/fields.json
+++ b/apps/epp-replace/translations/src/en/fields.json
@@ -233,5 +233,11 @@
   },
   "amend-declaration": {
     "label": "I have read and agree to this declaration"
+  },
+  "precursor-field": {
+    "hint": "Select an explosives precursor",
+    "options":{
+      "none_selected": "Select"
+    }
   }
 }

--- a/apps/epp-replace/translations/src/en/pages.json
+++ b/apps/epp-replace/translations/src/en/pages.json
@@ -164,6 +164,11 @@
     "make-change-application": "If you need to make changes to your application",
     "p6": "If you need to make changes to your replacement application or have any questions, contact"
   },
+  "select-precursor": {
+    "header": "Explosives precursors",
+    "p1": "Tell us which explosives precursors you want to import acquire use or possess.",
+    "p2": "If you need multiple explosives precursors, you can add each one separately."
+  },
   "confirm": {
     "header": "Check your answers",
     "subheader": "Review your answers below and amend if required before proceeding to declaration and payment.",

--- a/apps/epp-replace/translations/src/en/validation.json
+++ b/apps/epp-replace/translations/src/en/validation.json
@@ -224,5 +224,8 @@
     "date": "Enter a real date",
     "before": "Date you changed your name must be in the past",
     "after": "Date you changed your name must be after {{diff}}, your date of birth"
-}
+},
+  "precursor-field": {
+    "required" : "Select an explosive precursor"
+  }
 }

--- a/apps/epp-replace/views/select-precursor.html
+++ b/apps/epp-replace/views/select-precursor.html
@@ -1,0 +1,13 @@
+{{<partials-page}}
+  {{$page-content}}
+  <div>
+    <p class="govuk-body">{{#t}}pages.select-precursor.p1{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.select-precursor.p2{{/t}}</p>
+  </div>
+  
+  {{#fields}}
+    {{#renderField}}{{/renderField}}
+  {{/fields}}
+  {{#input-submit}}continue{{/input-submit}} 
+  {{/page-content}}
+{{/partials-page}}


### PR DESCRIPTION
## What? 
[EPP-200](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-200) -  Replace SELECT PRECURSOR page
## Why? 
To allow users to select a precursor from the drop down list
## How? 

- Page is created with required validation and content
- Renamed the field name across 4 forms for reusability 

## Testing?
Local and branch testing
## Screenshots (optional)
## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
