### PR TITLE
EPP-196 Create replace new address page

### DIFF
--- a/apps/epp-common/behaviours/after-date-validator.js
+++ b/apps/epp-common/behaviours/after-date-validator.js
@@ -10,7 +10,8 @@ module.exports = dobFieldName => superclass =>
         'amend-new-date-name-changed',
         'amend-new-date-moved-to-address',
         'new-renew-licence-refused-date',
-        'new-renew-offence-date'
+        'new-renew-offence-date',
+        'replace-new-date-moved-to-address'
       ];
 
       if (

--- a/apps/epp-replace/fields/index.js
+++ b/apps/epp-replace/fields/index.js
@@ -441,5 +441,73 @@ module.exports = {
         label: 'fields.precursor-field.options.none_selected'
       }
     ].concat(precursorList)
-  }
+  },
+  'replace-new-address-1': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--m',
+    className: ['govuk-input', 'govuk-input govuk-!-width-full'],
+    validate: [
+      'required',
+      { type: 'minlength', arguments: 2 },
+      { type: 'maxlength', arguments: 250 },
+      'notUrl'
+    ]
+  },
+  'replace-new-address-2': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--m',
+    className: ['govuk-input', 'govuk-input govuk-!-width-full'],
+    validate: [
+      { type: 'minlength', arguments: 2 },
+      { type: 'maxlength', arguments: 250 },
+      'notUrl'
+    ]
+  },
+  'replace-new-town-or-city': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--m',
+    className: ['govuk-input', 'govuk-input govuk-!-width-full'],
+    validate: [
+      'required',
+      { type: 'minlength', arguments: 2 },
+      { type: 'maxlength', arguments: 250 },
+      'notUrl'
+    ]
+  },
+  'replace-new-county': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--m',
+    className: ['govuk-input', 'govuk-input govuk-!-width-full'],
+    validate: [
+      { type: 'minlength', arguments: 2 },
+      { type: 'maxlength', arguments: 250 },
+      'notUrl'
+    ]
+  },
+  'replace-new-postcode': {
+    mixin: 'input-text',
+    labelClassName: 'govuk-label--m',
+    className: ['govuk-input', 'govuk-input--width-10'],
+    formatter: ['ukPostcode']
+  },
+  'replace-new-country': {
+    mixin: 'select',
+    validate: ['required'],
+    className: ['typeahead'],
+    labelClassName: 'govuk-label--m',
+    options: [
+      {
+        value: '',
+        label: 'fields.replace-new-country.options.none_selected'
+      }
+    ].concat(countries)
+  },
+  'replace-new-date-moved-to-address': dateComponent(
+    'replace-new-date-moved-to-address',
+    {
+      mixin: 'input-date',
+      legend: { className: 'govuk-fieldset__legend--m' },
+      validate: ['required', 'date', 'before']
+    }
+  )
 };

--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -244,14 +244,16 @@ module.exports = {
     },
     '/new-address': {
       fields: [
-        'replace-new-post-address-1',
-        'replace-new-post-address-2',
-        'replace-new-post-town-or-city',
-        'replace-new-post-county',
-        'replace-new-post-postcode',
-        'replace-new-post-country',
+        'replace-new-address-1',
+        'replace-new-address-2',
+        'replace-new-town-or-city',
+        'replace-new-county',
+        'replace-new-postcode',
+        'replace-new-country',
         'replace-new-date-moved-to-address'
       ],
+      behaviours: [AfterDateOfBirth('replace-date-of-birth'), PostcodeValidation],
+      locals: { captionHeading: 'Section 14 of 26' },
       next: '/upload-proof-address'
     },
     '/upload-proof-address': {

--- a/apps/epp-replace/sections/summary-data-sections.js
+++ b/apps/epp-replace/sections/summary-data-sections.js
@@ -174,6 +174,55 @@ module.exports = {
       }
     ]
   },
+  'replace-new-home-address': {
+    steps: [
+      {
+        step: '/new-address',
+        field: 'replace-new-address-1'
+      },
+      {
+        step: '/new-address',
+        field: 'replace-new-address-2'
+      },
+      {
+        step: '/new-address',
+        field: 'replace-new-town-or-city'
+      },
+      {
+        step: '/new-address',
+        field: 'replace-new-county'
+      },
+      {
+        step: '/new-address',
+        field: 'replace-new-postcode'
+      },
+      {
+        step: '/new-address',
+        field: 'replace-new-country'
+      },
+      {
+        step: '/new-address',
+        field: 'replace-new-date-moved-to-address',
+        parse: date => date && dateFormatter.format(new Date(date))
+      },
+      {
+        step: '/upload-proof-address',
+        field: 'replace-proof-address',
+        parse: (documents, req) => {
+          if (
+            req.sessionModel
+              .get('steps')
+              .includes('/upload-proof-address') &&
+            documents?.length > 0
+          ) {
+            return documents.map(file => file?.name)?.join('\n\n');
+          }
+
+          return null;
+        }
+      }
+    ]
+  },
   'applicant-name': {
     steps: [
       {

--- a/apps/epp-replace/translations/src/en/fields.json
+++ b/apps/epp-replace/translations/src/en/fields.json
@@ -59,6 +59,32 @@
           }
         }
       },
+      "replace-new-address-1": {
+        "label": "Address line 1"
+      },
+      "replace-new-address-2": {
+        "label": "Address line 2 (optional)"
+      },
+      "replace-new-town-or-city": {
+        "label": "Town or city"
+      },
+      "replace-new-county": {
+        "label": "County, state, province (optional)"
+      },
+      "replace-new-postcode": {
+        "label": "Postcode (required for UK)",
+        "hint": "Postcode is optional if your address is outside the UK"
+      },
+      "replace-new-country": {
+        "label": "Country",
+        "options": {
+          "none_selected": "Select"
+        }
+      },
+      "replace-new-date-moved-to-address": {
+          "legend": "When did you move to this address?",
+          "hint": " For example, 30 09 1969"
+      },
       "replace-licence": {
         "legend": "Why do you need a replacement licence?",
         "options": {

--- a/apps/epp-replace/translations/src/en/pages.json
+++ b/apps/epp-replace/translations/src/en/pages.json
@@ -11,6 +11,9 @@
   "new-name": {
     "header": "What is your new name?"
   },
+  "new-address": {
+    "header": "What is your new address?"
+  },
   "upload-british-passport": {
     "header": "Upload British passport",
     "label": "Upload a file",
@@ -195,6 +198,9 @@
       },
       "licence-details": {
         "header": "Licence details"
+      },
+      "replace-new-home-address": {
+        "header": "New address"
       },
       "replace-licence": {
         "header": "Replacement reason"

--- a/apps/epp-replace/translations/src/en/validation.json
+++ b/apps/epp-replace/translations/src/en/validation.json
@@ -230,5 +230,40 @@
 },
   "precursor-field": {
     "required" : "Select an explosive precursor"
-  }
+  },
+  "replace-new-address-1": {
+    "required": "Enter address line 1, typically the building and street",
+    "maxlength": "Address line 1 must be between 2 and 250 characters",
+    "minlength": "Address line 2 must be between 2 and 250 characters",
+    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+   },
+   "replace-new-address-2": {
+     "maxlength": "Address line 1 must be between 2 and 250 characters",
+     "minlength": "Address line 2 must be between 2 and 250 characters",
+     "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+   },
+   "replace-new-town-or-city": {
+     "required": "Enter town or city",
+     "maxlength": "Town or city must be between 2 and 250 characters",
+     "minlength": "Address line 2 must be between 2 and 250 characters",
+     "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+   },
+   "replace-new-county": {
+     "maxlength": "County, state or province must be between 2 and 250 characters",
+     "minlength": "Address line 2 must be between 2 and 250 characters",
+     "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+   },
+   "replace-new-postcode": {
+     "required" : "Enter a UK postcode",
+     "postcode" : "Enter a real UK postcode"
+   },
+   "replace-new-country": {
+     "required": "Select a country of address"
+   },
+   "replace-new-date-moved-to-address": {
+       "required": "Enter the move date to this address",
+       "date": "Enter a real date",
+       "before": "Date you moved to this address must be in the past",
+       "after": "Date you moved to this address must be after {{diff}}, your date of birth"
+   }
 }

--- a/utilities/helpers/postcode-validation.js
+++ b/utilities/helpers/postcode-validation.js
@@ -7,7 +7,8 @@ const postCodeCountriesMap = {
   'replace-home-postcode': 'replace-home-country',
   'new-renew-previous-home-address-postcode': 'new-renew-previous-home-address-country',
   'amend-new-postcode': 'amend-new-country',
-  'new-renew-doctor-postcode': 'new-renew-doctor-country'
+  'new-renew-doctor-postcode': 'new-renew-doctor-country',
+  'replace-new-postcode': 'replace-new-country'
 };
 
 module.exports = superclass =>


### PR DESCRIPTION
## What? 
[EPP-196](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-196) - Create REPLACE new address page - EPP

## Why? 
Allows user to enter new address

## How? 
- Added Heading and inputs for page
- Added validations for page

## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging