### PR TITLE
EPP-288 Correct validation message bug

### DIFF
--- a/apps/epp-replace/translations/src/en/validation.json
+++ b/apps/epp-replace/translations/src/en/validation.json
@@ -250,7 +250,7 @@
    },
    "replace-new-county": {
      "maxlength": "County, state or province must be between 2 and 250 characters",
-     "minlength": "County, state, province must be between 2 and 250 characters",
+     "minlength": "County, state or province must be between 2 and 250 characters",
      "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
    },
    "replace-new-postcode": {

--- a/apps/epp-replace/translations/src/en/validation.json
+++ b/apps/epp-replace/translations/src/en/validation.json
@@ -245,12 +245,12 @@
    "replace-new-town-or-city": {
      "required": "Enter town or city",
      "maxlength": "Town or city must be between 2 and 250 characters",
-     "minlength": "Address line 2 must be between 2 and 250 characters",
+     "minlength": "Town or city must be between 2 and 250 characters",
      "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
    },
    "replace-new-county": {
      "maxlength": "County, state or province must be between 2 and 250 characters",
-     "minlength": "Address line 2 must be between 2 and 250 characters",
+     "minlength": "County, state, province must be between 2 and 250 characters",
      "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
    },
    "replace-new-postcode": {


### PR DESCRIPTION
## What? 
[EPP-288](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-288) - fix validation error messages in new address - Replace - EPP

## Why? 


## How? 


## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
