### PR TITLE
EPP-88 create select poison page

### DIFF
--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -9,6 +9,7 @@ const {
 const countersignatoryYears = require('../../../utilities/constants/countersignatory-years');
 const { textAreaDefaultLength } = require('../../../utilities/helpers');
 const precursorList = require('../../../utilities/constants/explosive-precursors');
+const poisonsList = require('../../../utilities/constants/poisons.js');
 
 module.exports = {
   'new-renew-title': {
@@ -751,6 +752,18 @@ module.exports = {
     className: ['govuk-radios', 'govuk-radios--inline'],
     options: ['yes', 'no'],
     validate: 'required'
+  },
+  'poison-field': {
+    mixin: 'select',
+    validate: ['required'],
+    labelClassName: 'visuallyhidden',
+    className: ['govuk-select', 'govuk-input--width-2'],
+    options: [
+      {
+        value: '',
+        label: 'fields.poison-field.options.none_selected'
+      }
+    ].concat(poisonsList)
   },
   'new-renew-regulated-explosives-precursors-options': {
     mixin: 'radio-group',

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -18,17 +18,13 @@ const RemoveDocument = require('../epp-common/behaviours/remove-document');
 const DobEditRedirect = require('../epp-common/behaviours/dob-edit-redirect');
 const DobUnder18Redirect = require('../epp-common/behaviours/dob-under18-redirect');
 const UploadFileCounter = require('../epp-common/behaviours/uploaded-files-counter');
-
 const DeleteRedundantDocuments = require('../epp-common/behaviours/delete-redundant-documents');
-
 const InitiatePaymentRequest = require('../epp-common/behaviours/initiate-payment-request');
 const GetPaymentInfo = require('../epp-common/behaviours/get-payment-info');
 const JourneyValidator = require('../epp-common/behaviours/journey-validator');
 const AfterDateOfBirth = require('../epp-common/behaviours/after-date-validator');
-
 const SaveAddress = require('../epp-common/behaviours/save-home-other-address');
 const SaveCounterSignatoryAddress = require('../epp-common/behaviours/save-countersignatory-address');
-
 const NoPrecursorOrPoison = require('../epp-common/behaviours/no-precursor-poison-navigate');
 const NoPrecursorPoisonBackLink = require('./behaviours/no-poison-precursor-back-link');
 
@@ -635,6 +631,8 @@ module.exports = {
       behaviours: [NoPrecursorPoisonBackLink]
     },
     '/select-poison': {
+      fields: ['poison-field'],
+      continueOnEdit: true,
       next: '/poison-details',
       locals: {
         sectionNo: {

--- a/apps/epp-new/translations/src/en/fields.json
+++ b/apps/epp-new/translations/src/en/fields.json
@@ -444,6 +444,12 @@
       }
     }
   },
+  "poison-field": {
+    "hint": "Select a poison",
+      "options":{
+        "none_selected": "Select poison"
+    }
+  },
   "new-renew-regulated-explosives-precursors-options": {
     "legend":"Does your licence need to cover explosives precursors?",
     "options": {

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -77,6 +77,11 @@
     "files-uploaded": "Files uploaded",
     "uploading-document": "Uploading your document..."
   },
+  "select-poison": {
+    "header": "Poisons",
+    "p1": "Tell us which poisons you want to import, acquire, use or possess.",
+    "p2": "If you need multiple poisons, you can add each one separately."
+  },
   "countersignatory-details": {
     "header": "Countersignatory details",
     "description": "Your countersignatory must not be a parent or relative, unless you are under 18. If you are under 18, your countersignatory must be your parent or legal guardian."
@@ -350,6 +355,9 @@
       },
       "otheraddresses": {
         "label": "Previous addresses"
+      },
+      "poison-field": {
+        "label": "Poisons"
       },
       "new-renew-countersignatory-middlename": {
         "label": "Middle names"

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -28,6 +28,9 @@
         "required": "Enter a contact email address",
         "email": "Enter a real email address"
     },
+    "poison-field": {
+    "required": "Select a poison"
+    },
     "new-renew-applicant-Id-type": {
       "required": "Select which identity document you want to use"
     },

--- a/apps/epp-new/views/select-poisons.html
+++ b/apps/epp-new/views/select-poisons.html
@@ -1,0 +1,14 @@
+{{<partials-page}}
+  {{$page-content}}
+   <div>
+    <p class="govuk-body">{{#t}}pages.select-poisons.p1{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.select-poisons.p2{{/t}}</p>
+   </div>
+  {{#fields}}
+    {{#renderField}}{{/renderField}}
+  {{/fields}}
+
+  {{#input-submit}}continue{{/input-submit}} 
+  
+  {{/page-content}}
+  {{/partials-page}}


### PR DESCRIPTION
## What? 
Add a select poison page to the form as per jira ticket [EPP-88](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-88)
## Why? 
to allow user to add poison from dropdown menu
## How? 
- add select-poison step to `index.js` 
- add `select-poison.html`
- add "/select-poison" page content to `page.json` 
- add ` poison-field` to 
  * fields/index.js, 
  * fields.json 
  * validation.json

## Testing?
manual test
## Screenshots (optional)
## Anything Else? (optional)
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
