### PR TITLE
EPP-89 Poison Details page for new renew journey

### DIFF
--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -4,10 +4,11 @@ const countries = require('../../../utilities/constants/countries');
 const {
   isWithoutFullStop,
   validInternationalPhoneNumber,
-  isValidUkDrivingLicenceNumber
+  isValidUkDrivingLicenceNumber,
+  isValidConcentrationValue,
+  textAreaDefaultLength
 } = require('../../../utilities/helpers');
 const countersignatoryYears = require('../../../utilities/constants/countersignatory-years');
-const { textAreaDefaultLength } = require('../../../utilities/helpers');
 const precursorList = require('../../../utilities/constants/explosive-precursors');
 const poisonsList = require('../../../utilities/constants/poisons.js');
 
@@ -764,6 +765,88 @@ module.exports = {
         label: 'fields.poison-field.options.none_selected'
       }
     ].concat(poisonsList)
+  },
+  'why-need-poison': {
+    mixin: 'textarea',
+    validate: ['required', 'notUrl', textAreaDefaultLength],
+    attributes: [{ attribute: 'rows', value: 5 }],
+    labelClassName: 'govuk-label--s'
+  },
+  'how-much-poison': {
+    mixin: 'input-text',
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
+    className: ['govuk-input', 'govuk-input--width-10'],
+    labelClassName: 'govuk-label--s'
+  },
+  'compound-or-salt': {
+    mixin: 'textarea',
+    validate: ['required', 'notUrl', textAreaDefaultLength],
+    attributes: [{ attribute: 'rows', value: 5 }],
+    labelClassName: 'govuk-label--s'
+  },
+  'what-concentration-poison': {
+    mixin: 'input-text',
+    validate: [
+      'required',
+      isValidConcentrationValue,
+      { type: 'maxlength', arguments: 250 },
+      'notUrl'
+    ],
+    className: ['govuk-input', 'govuk-input--width-5'],
+    labelClassName: 'govuk-label--s',
+    attributes: [{ suffix: '%' }]
+  },
+  'where-to-store-poison': {
+    mixin: 'checkbox-group',
+    validate: ['required'],
+    legend: {
+      className: 'govuk-label--s'
+    },
+    options: [
+      {
+        value: 'store-poison-home-address-value'
+      },
+      {
+        value: 'store-poison-other-address-value',
+        toggle: 'store-poison-other-address',
+        child: 'textarea'
+      }
+    ]
+  },
+  'store-poison-other-address': {
+    mixin: 'textarea',
+    validate: ['required', textAreaDefaultLength, 'notUrl'],
+    dependent: {
+      field: 'where-to-store-poison',
+      value: 'store-poison-other-address-value'
+    },
+    attributes: [{ attribute: 'rows', value: 5 }]
+  },
+  'where-to-use-poison': {
+    mixin: 'checkbox-group',
+    validate: ['required'],
+    legend: {
+      className: 'govuk-label--s'
+    },
+    options: [
+      {
+        value: 'use-poison-home-address'
+      },
+      {
+        value: 'use-poison-other-address-value',
+        toggle: 'poison-use-other-address',
+        child: 'textarea'
+      }
+    ]
+  },
+  'poison-use-other-address': {
+    mixin: 'textarea',
+    validate: ['required', textAreaDefaultLength, 'notUrl'],
+    dependent: {
+      field: 'where-to-use-poison',
+      value: 'use-poison-other-address-value'
+    },
+    attributes: [{ attribute: 'rows', value: 5 }]
   },
   'new-renew-regulated-explosives-precursors-options': {
     mixin: 'radio-group',

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -27,6 +27,7 @@ const SaveAddress = require('../epp-common/behaviours/save-home-other-address');
 const SaveCounterSignatoryAddress = require('../epp-common/behaviours/save-countersignatory-address');
 const NoPrecursorOrPoison = require('../epp-common/behaviours/no-precursor-poison-navigate');
 const NoPrecursorPoisonBackLink = require('./behaviours/no-poison-precursor-back-link');
+const RenderPoisonDetails = require('../epp-common/behaviours/render-poison-detail');
 
 module.exports = {
   name: 'EPP form',
@@ -642,7 +643,18 @@ module.exports = {
       }
     },
     '/poison-details': {
-      fields: [],
+      behaviours: [RenderPoisonDetails('poison-field')],
+      fields: [
+        'why-need-poison',
+        'how-much-poison',
+        'compound-or-salt',
+        'what-concentration-poison',
+        'where-to-store-poison',
+        'where-to-use-poison',
+        'store-poison-other-address',
+        'poison-use-other-address'
+      ],
+      continueOnEdit: true,
       next: '/poison-summary',
       locals: {
         sectionNo: {

--- a/apps/epp-new/translations/src/en/fields.json
+++ b/apps/epp-new/translations/src/en/fields.json
@@ -450,6 +450,108 @@
         "none_selected": "Select poison"
     }
   },
+  "amend-why-need-precursor":{
+    "label": "{{values.whyNeedPrecursorLabel}}",
+    "hint": "Detailed answers mean we can process your application faster",
+    "summary-heading": "{{values.whyNeedPrecursorLabel}}"
+  },
+  "amend-how-much-precursor":{
+    "label": "How much do you wish to acquire at any one time within a 6-month period?",
+    "hint": "Enter the amount and the unit. For example, 10 litres",
+    "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
+  },
+  "amend-what-concentration-precursor":{
+    "label": "What concentration % w/w of the substance do you need?",
+    "summary-heading": "What concentration % w/w of the substance do you need?"
+  },
+  "amend-where-to-store-precursor": {
+    "legend": "{{values.whereToStorePrecursorLegend}}",
+    "summary-heading": "{{values.whereToStorePrecursorLegend}}",
+    "hint": "This must be in the UK",
+    "options": {
+      "amend-store-precursors-home-address": {
+        "label": "{{values.homeAddressInline}}",
+        "summary-heading": "{{values.homeAddressInline}}"
+      },
+      "amend-store-precursors-other-address": {
+        "label": "Other address"
+      }
+    }
+  },
+  "store-precursors-other-address": {
+    "label": "{{values.storePrecursorOtherAddressLabel}}",
+    "hint": "Enter a UK address"
+  },
+  "amend-where-to-use-precursor": {
+    "legend": "{{values.whereToUsePrecursorLegend}}",
+    "hint": "This must be in the UK",
+    "summary-heading": "{{values.whereToUsePrecursorLegend}}",
+    "options": {
+      "amend-use-precursors-home-address": {
+        "label": "{{values.homeAddressInline}}",
+        "summary-heading": "{{values.homeAddressInline}}"
+      },
+      "amend-use-precursors-other-address": {
+        "label": "Other address"
+      }
+    }
+  },
+  "precursors-use-other-address": {
+    "label": "{{values.usePrecursorOtherAddressLabel}}",
+    "hint": "Enter a UK address"
+  },
+  "why-need-poison":{
+    "label": "{{values.whyNeedPoisonLabel}}",
+    "hint": "Detailed answers mean we can process your application faster",
+    "summary-heading": "{{values.whyNeedPoisonLabel}}"
+  },
+  "how-much-poison":{
+    "label": "How much do you wish to acquire at any one time within a 6-month period?",
+    "hint": "Enter the amount and the unit. For example, 10 litres",
+    "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
+  },
+  "compound-or-salt": {
+    "label": "Specific compound or salt",
+    "summary-heading": "Specific compound or salt"
+  },
+  "what-concentration-poison":{
+    "label": "What concentration % w/w of the substance do you need?",
+    "summary-heading": "What concentration % w/w of the substance do you need?"
+  },
+  "where-to-store-poison": {
+    "legend": "{{values.whereToStorePoisonLegend}}",
+    "hint": "This must be in the UK",
+    "summary-heading": "{{values.whereToStorePoisonLegend}}",
+    "options": {
+      "store-poison-home-address-value": {
+        "label": "{{values.homeAddressInline}}"
+      },
+      "store-poison-other-address-value": {
+        "label": "Other address"
+      }
+    }
+  },
+  "store-poison-other-address": {
+    "label": "{{values.storePoisonOtherAddressLabel}}",
+    "hint": "Enter a UK address"
+  },
+  "where-to-use-poison": {
+    "legend": "{{values.whereToUsePoisonLegend}}",
+    "hint": "This must be in the UK",
+    "summary-heading": "{{values.whereToUsePoisonLegend}}",
+    "options": {
+      "use-poison-home-address": {
+        "label": "{{values.homeAddressInline}}"
+      },
+      "use-poison-other-address-value": {
+        "label": "Other address"
+      }
+    }
+  },
+  "poison-use-other-address": {
+    "label": "{{values.usePoisonOtherAddressLabel}}",
+    "hint": "Enter a UK address"
+  },
   "new-renew-regulated-explosives-precursors-options": {
     "legend":"Does your licence need to cover explosives precursors?",
     "options": {

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -82,6 +82,9 @@
     "p1": "Tell us which poisons you want to import, acquire, use or possess.",
     "p2": "If you need multiple poisons, you can add each one separately."
   },
+  "poison-details":{
+    "header": "{{values.poison-field}}"
+  },
   "countersignatory-details": {
     "header": "Countersignatory details",
     "description": "Your countersignatory must not be a parent or relative, unless you are under 18. If you are under 18, your countersignatory must be your parent or legal guardian."

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -1,93 +1,129 @@
 {
-    "new-renew-title": {
-        "required": "Select your title"
-    },
-    "new-renew-first-name": {
-        "required": "Enter your first name",
-        "maxlength": "First name must between 1 and 250 characters",
-        "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
-    },
-    "new-renew-middle-name": {
-         "maxlength": "Middle names must be between 250 characters or less",
-         "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
-    },
-    "new-renew-last-name": {
-        "required": "Enter your last name",
-        "maxlength": "Last name must be between 1 and 250 characters",
-        "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
-    },
-    "new-renew-other-names": {
-        "required": "Select if you have ever used any other names"
-    },
-    "new-renew-phone-number": {
-        "required": "Enter your telephone number",
-        "validInternationalPhoneNumber": "Enter a real telephone number",
-        "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
-    },
-    "new-renew-email": {
-        "required": "Enter a contact email address",
-        "email": "Enter a real email address"
-    },
-    "poison-field": {
+  "new-renew-title": {
+    "required": "Select your title"
+  },
+  "new-renew-first-name": {
+    "required": "Enter your first name",
+    "maxlength": "First name must between 1 and 250 characters",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "new-renew-middle-name": {
+    "maxlength": "Middle names must be between 250 characters or less",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "new-renew-last-name": {
+    "required": "Enter your last name",
+    "maxlength": "Last name must be between 1 and 250 characters",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "new-renew-other-names": {
+    "required": "Select if you have ever used any other names"
+  },
+  "new-renew-phone-number": {
+    "required": "Enter your telephone number",
+    "validInternationalPhoneNumber": "Enter a real telephone number",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "new-renew-email": {
+    "required": "Enter a contact email address",
+    "email": "Enter a real email address"
+  },
+  "poison-field": {
     "required": "Select a poison"
-    },
-    "new-renew-applicant-Id-type": {
-      "required": "Select which identity document you want to use"
-    },
-    "new-renew-UK-passport-number": {
-      "required": "Enter your passport number",
-      "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer",
-      "maxlength": "Passport number must be 9 characters or less",
-      "alphanum": "Passport number must only include numbers and letters a-z"
-
-    },
-    "new-renew-EU-passport-number": {
-      "required": "Enter your passport number",
-      "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer",
-      "maxlength": "Passport number must be 9 characters or less",
-      "alphanum": " Passport number must only include numbers and letters a-z"
-    },
-    "new-renew-Uk-driving-licence-number": {
-      "required": "Enter your driving licence number",
-      "isValidUkDrivingLicenceNumber": "Enter a real UK driving licence number",
-      "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer",
-      "minlength": "Driving licence number must be 16 characters"
-    },
-    "medical-declaration": {
-        "required" : "Confirm you have read and agree to this medical declaration"
-    },
-    "new-renew-other-name-start-date": {
-        "required": "Enter when you started using this name",
-        "date": "Enter a real date",
-        "before": "Date you started using this name must be in the past"
-    },
-    "new-renew-other-name-title": {
-        "required": "Select your title"
-    },
-    "new-renew-other-name-first-name": {
-        "required": "Enter your first name",
-        "maxlength": "First name must between 1 and 250 characters",
-        "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
-    },
-    "new-renew-other-name-middle-name": {
-         "maxlength": "Middle names must be between 250 characters or less",
-         "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
-    },
-    "new-renew-other-name-last-name": {
-        "required": "Enter your last name",
-        "maxlength": "Last name must be between 1 and 250 characters",
-        "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
-    },
-    "new-renew-other-name-stop-date": {
-        "date": "Enter a real date",
-        "before": "Date you stopped using this name must be in the past",
-        "maxlength": "Last name must be between 1 and 250 characters",
-        "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
-    },
-    "new-renew-has-seen-doctor":{
+  },
+  "why-need-poison": {
+    "required": "Explain why you need this poison",
+    "textAreaDefaultLength": "Reason why you need this poison must be less than 2,000 characters",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "how-much-poison": {
+    "required": "Enter how much of poison you wish to acquire at any one time",
+    "maxlength": "Quantity of the explosive precursor you wish to acquire must be 250 characters or less",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "compound-or-salt": {
+    "required": "Enter the specific compound or salt",
+    "textAreaDefaultLength": " Specific compound or salt must be less than 2,000 characters",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "what-concentration-poison": {
+    "required": "Enter what concentration % w/w you need",
+    "isValidConcentrationValue": "Concentration % w/w must only include numbers or special characters",
+    "maxlength": "Concentration % w/w must be 250 characters or less",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "where-to-store-poison": {
+    "required": "Select where you will store the poison"
+  },
+  "where-to-use-poison": {
+    "required": "Select where you will use the poison"
+  },
+  "store-poison-other-address": {
+    "required": "Enter the address where you will store the poison",
+    "textAreaDefaultLength": "Storage address must be 2,000 characters or less",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "poison-use-other-address": {
+    "required": "Enter the address where you will use the poison",
+    "textAreaDefaultLength": "Usage address must be 2,000 characters or less",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "new-renew-applicant-Id-type": {
+    "required": "Select which identity document you want to use"
+  },
+  "new-renew-UK-passport-number": {
+    "required": "Enter your passport number",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer",
+    "maxlength": "Passport number must be 9 characters or less",
+    "alphanum": "Passport number must only include numbers and letters a-z"
+  },
+  "new-renew-EU-passport-number": {
+    "required": "Enter your passport number",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer",
+    "maxlength": "Passport number must be 9 characters or less",
+    "alphanum": " Passport number must only include numbers and letters a-z"
+  },
+  "new-renew-Uk-driving-licence-number": {
+    "required": "Enter your driving licence number",
+    "isValidUkDrivingLicenceNumber": "Enter a real UK driving licence number",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer",
+    "minlength": "Driving licence number must be 16 characters"
+  },
+  "medical-declaration": {
+    "required": "Confirm you have read and agree to this medical declaration"
+  },
+  "new-renew-other-name-start-date": {
+    "required": "Enter when you started using this name",
+    "date": "Enter a real date",
+    "before": "Date you started using this name must be in the past"
+  },
+  "new-renew-other-name-title": {
+    "required": "Select your title"
+  },
+  "new-renew-other-name-first-name": {
+    "required": "Enter your first name",
+    "maxlength": "First name must between 1 and 250 characters",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "new-renew-other-name-middle-name": {
+    "maxlength": "Middle names must be between 250 characters or less",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "new-renew-other-name-last-name": {
+    "required": "Enter your last name",
+    "maxlength": "Last name must be between 1 and 250 characters",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "new-renew-other-name-stop-date": {
+    "date": "Enter a real date",
+    "before": "Date you stopped using this name must be in the past",
+    "maxlength": "Last name must be between 1 and 250 characters",
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+  },
+  "new-renew-has-seen-doctor": {
     "required": "Select if you have seen a doctor for any mental health-related problems"
   },
-    "new-renew-received-treatment" : {
+  "new-renew-received-treatment": {
     "required": "Select if you have ever had any drug or alcohol-related health problems?"
   },
   "new-renew-other-firearms-licence": {
@@ -190,13 +226,13 @@
     "unsaved": "Your file could not be uploaded – try again",
     "maxFileSize": "The selected file must be 25MB or smaller",
     "fileType": "The selected file must be a JPG, JPEG, PDF or PNG",
-    "maxNewRenewBritishPassport" : "You can only upload upto {{maxNewRenewBritishPassport}} files or less. Remove a file before uploading another",
-    "maxNewRenewEuPassport" : "You can only upload upto {{maxNewRenewEuPassport}} files or less. Remove a file before uploading another",
-    "maxNewRenewProofAddress" : "You can only upload upto {{maxNewRenewProofAddress}} files or less. Remove a file before uploading another",
-    "maxNewRenewDrivingLicence" : "You can only upload upto {{maxNewRenewDrivingLicence}} files or less. Remove a file before uploading another",
-    "maxNewRenewMedicalForm" : "You can only upload upto {{maxNewRenewMedicalForm}} files or less. Remove a file before uploading another",
-    "maxNewRenewCertificateConduct" : "You can only upload upto {{maxNewRenewCertificateConduct}} files or less. Remove a file before uploading another",
-    "maxNewRenewBirthCertificate" : "You can only upload upto {{maxNewRenewBirthCertificate}} files or less. Remove a file before uploading another"
+    "maxNewRenewBritishPassport": "You can only upload upto {{maxNewRenewBritishPassport}} files or less. Remove a file before uploading another",
+    "maxNewRenewEuPassport": "You can only upload upto {{maxNewRenewEuPassport}} files or less. Remove a file before uploading another",
+    "maxNewRenewProofAddress": "You can only upload upto {{maxNewRenewProofAddress}} files or less. Remove a file before uploading another",
+    "maxNewRenewDrivingLicence": "You can only upload upto {{maxNewRenewDrivingLicence}} files or less. Remove a file before uploading another",
+    "maxNewRenewMedicalForm": "You can only upload upto {{maxNewRenewMedicalForm}} files or less. Remove a file before uploading another",
+    "maxNewRenewCertificateConduct": "You can only upload upto {{maxNewRenewCertificateConduct}} files or less. Remove a file before uploading another",
+    "maxNewRenewBirthCertificate": "You can only upload upto {{maxNewRenewBirthCertificate}} files or less. Remove a file before uploading another"
   },
   "new-renew-previous-home-address-line1": {
     "required": "Enter address line 1, typically the building and street",
@@ -251,7 +287,6 @@
   },
   "new-renew-countersignatory-years": {
     "required": "Select how many years you have known your countersignatory"
-
   },
   "new-renew-countersignatory-howyouknow": {
     "required": "Enter how you know your countersignatory",
@@ -264,30 +299,30 @@
     "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
   "new-renew-countersignatory-address-1": {
-    "required" : "Enter address line 1, typically the building and street",
+    "required": "Enter address line 1, typically the building and street",
     "minlength": "Address line 1 must be between 2 and 250 characters",
     "maxlength": "Address line 1 must be between 2 and 250 characters",
-    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
   "new-renew-countersignatory-address-2": {
     "minlength": "Address line 2 must be between 2 and 250 characters",
     "maxlength": "Address line 2 must be between 2 and 250 characters",
-    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
   "new-renew-countersignatory-town-or-city": {
-    "required" : "Enter town or city",
+    "required": "Enter town or city",
     "minlength": "Town or city must be between 2 and 250 characters",
     "maxlength": "Town or city must be between 2 and 250 characters",
-    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
   "new-renew-countersignatory-postcode": {
-    "required" : "Enter a UK postcode",
-    "postcode" : "Enter a real UK postcode"
+    "required": "Enter a UK postcode",
+    "postcode": "Enter a real UK postcode"
   },
   "new-renew-countersignatory-phone-number": {
     "required": "Enter your countersignatory's telephone number",
     "validInternationalPhoneNumber": "Enter a real telephone number",
-    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
   "new-renew-countersignatory-email": {
     "required": "Enter your countersignatory's email address",
@@ -302,7 +337,7 @@
   "new-renew-why-licence-refused": {
     "required": "Enter why the licence was refused or revoked",
     "textAreaDefaultLength": "Reason why you need this explosive precursor must be less than 2,000 characters",
-    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
   "new-renew-licence-refused-date": {
     "required": "Enter a date when the licence was refused or revoked",
@@ -314,7 +349,7 @@
     "required": "Enter a name for the offence",
     "minlength": "Offence name must be between 2 and 250 characters",
     "maxlength": "Offence name must be between 2 and 250 characters",
-    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
   "new-renew-offence-country": {
     "required": "Select a country the offence was committed in"
@@ -332,7 +367,6 @@
     "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer",
     "maxlength": "Passport number must be 9 characters or less",
     "alphanum": "Passport number must only include numbers and letters a-z"
-
   },
   "new-renew-countersignatory-EU-passport-number": {
     "required": "Enter your passport number",
@@ -372,7 +406,7 @@
     "required": "Select your doctor's country of address"
   },
   "precursor-field": {
-    "required" : "Select an explosive precursor"
+    "required": "Select an explosive precursor"
   },
   "new-renew-poisons-options": {
     "required": "Select if your licence needs to cover poisons"


### PR DESCRIPTION
## What? 
Add to form the poison detail page as per ticket [EPP-89](https://collaboration.homeoffice.gov.uk/jira/secure/RapidBoard.jspa?rapidView=4360&projectKey=EPP&view=detail&selectedIssue=EPP-89#:~:text=Ready,-for%20Test)
## Why? 
to allow user to provide information about the poison storage and percentage for which is apply for licence
## How? 
- add step and fields to `index.js`
- add fields to 
  * `fields/index.js`,
  * ` pages.json`, 
  * `fields.json`, 
  * `validation.json`

configured behaviours mirroring amend journey

## Testing?
manual 
## Screenshots (optional)
## Anything Else? (optional)
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
