### PR TITLE
EPP-87 new-renew PRECURSOR SUMMARY

### DIFF
--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -560,7 +560,9 @@ module.exports = {
       }
     },
     '/explosives-precursors': {
-      behaviours: [NoPrecursorOrPoison],
+      behaviours: [NoPrecursorOrPoison, ResetSectionSummary(
+        ['precursors-details-aggregate'],
+        'new-renew-regulated-explosives-precursors-options')],
       fields: ['new-renew-regulated-explosives-precursors-options'],
       forks: [
         {
@@ -612,7 +614,24 @@ module.exports = {
       }
     },
     '/precursors-summary': {
-      fields: [],
+      behaviours: [
+        AggregateSaveEditPrecursorPoison,
+        ParseSummaryPrecursorsPoisons,
+        EditRouteReturn
+      ],
+      aggregateTo: 'precursors-details-aggregate',
+      aggregateFrom: [
+        'display-precursor-title',
+        'why-need-precursor',
+        'how-much-precursor',
+        'what-concentration-precursor',
+        'where-to-store-precursor',
+        'where-to-use-precursor'
+      ],
+      titleField: ['precursor-field'],
+      addStep: 'select-precursor',
+      addAnotherLinkText: 'explosives precursors',
+      continueOnEdit: false,
       next: '/poisons',
       locals: {
         sectionNo: {

--- a/apps/epp-new/sections/summary-data-sections.js
+++ b/apps/epp-new/sections/summary-data-sections.js
@@ -348,6 +348,30 @@ module.exports = {
       }
     ]
   },
+  'explosives-precursor-details': {
+    steps: [
+      {
+        step: '/precursors-summary',
+        field: 'precursors-details-aggregate',
+        parse: list => {
+          if (!list?.aggregatedValues) {
+            return null;
+          }
+          for (const item of list.aggregatedValues) {
+            item.fields.map(element => {
+              if (element.field === 'display-precursor-title') {
+                element.parsed = item.joinTitle;
+              } else {
+                element.field;
+                element.omitChangeLink = true;
+              }
+            });
+          }
+          return list;
+        }
+      }
+    ]
+  },
   'licence-for-poisons': {
     steps: [
       {

--- a/apps/epp-new/translations/src/en/pages.json
+++ b/apps/epp-new/translations/src/en/pages.json
@@ -267,6 +267,9 @@
   "precursor-details":{
     "header": "{{values.precursor-field}}"
   },
+  "precursors-summary": {
+    "header": "Explosives precursors on your licence"
+  },
   "confirm": {
     "header": "Check your answers",
     "title": "Check your answers – Apply for an explosives precursors and poisons licence",
@@ -300,6 +303,9 @@
       "licence-for-explosives-precursors": {
         "header": "Licence for explosives precursors"
       },
+      "explosives-precursor-details":{
+        "header": "Explosives precursors"
+     },
       "licence-for-poisons": {
         "header": "Licence for poisons"
       },
@@ -368,6 +374,27 @@
       "otheraddresses": {
         "label": "Previous addresses"
       },
+      "precursor-field": {
+        "label": "Explosives precursors"
+     },
+     "display-precursor-title": {
+        "label": "Explosives precursors"
+     },
+     "why-need-precursor": {
+       "label": "For what purpose do you need this regulated substance?"
+     },
+     "how-much-precursor": {
+       "label": "How much do you wish to acquire?"
+     },
+     "what-concentration-precursor": {
+       "label": "What concentration % w/w of the substance do you need for your intended purpose?"
+     },
+     "where-to-store-precursor": {
+       "label":"Storage address"
+     },
+     "where-to-use-precursor": {
+       "label": "Usage address"
+     },
       "poison-field": {
         "label": "Poison"
       },

--- a/apps/epp-new/views/partials/aggregator-summary-table.html
+++ b/apps/epp-new/views/partials/aggregator-summary-table.html
@@ -8,7 +8,7 @@
             <a href="{{baseUrl}}/{{route}}/delete/{{index}}" class="govuk-!-margin-left-3">{{#t}}buttons.remove{{/t}}<span class="visuallyhidden">{{joinTitle}}</span></a>
         </div>
     </div>
-    <dl class="govuk-summary-list govuk-!-width-full">
+    <dl class="govuk-summary-list looped-records govuk-!-width-full">
         {{#fields}}
         {{#showInSummary}}
           <div class="govuk-summary-list__row">

--- a/apps/epp-new/views/precursors-summary.html
+++ b/apps/epp-new/views/precursors-summary.html
@@ -1,0 +1,11 @@
+{{<partials-page}}
+  {{$page-content}}
+  {{> partials-aggregator-summary-table}}
+  <br>
+  <a href="{{baseUrl}}/{{addStep}}" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+      Add another {{addAnotherLinkText}}
+  </a>
+  <br>
+  {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}


### PR DESCRIPTION
## What? 
create a precursor summary page as per Jira ticket [EPP-87](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-87)
## Why? 
to allow user to review the precursors' information provided before continuing and submit the form.
## How? 
- add precursor summary step to `index.js` and `summary-data-section.js`
- add content to `pages.json`
- add view `precursors-summary.html`
## Testing?
manual test
## Screenshots (optional)
## Anything Else? (optional)
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
