### PR TITLE
EPP-282: Update html-pdf-converter image to latest v3.0.0

### DIFF
--- a/kube/html-pdf/html-pdf-deployment.yml
+++ b/kube/html-pdf/html-pdf-deployment.yml
@@ -38,8 +38,8 @@ spec:
         {{ else }}
         - name: html-pdf-converter
         {{ end }}
-          # html-pdf-converter:v2.1.0
-          image: quay.io/ukhomeofficedigital/html-pdf-converter@sha256:45814848f0c1d56169ab90990891b03d52d59d7558255cfca8ed2ce2a02d034e
+          # html-pdf-converter: v3.0.0 updated on 23/01/2024
+          image: quay.io/ukhomeofficedigital/html-pdf-converter:3.0.0@sha256:2f13eb3bc9d396f2685e22a66b40613a44dfd9956412fe2752477601bb33772c
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
## What?
* Using html-pdf-converter image with Node v 22 and upgraded node packages
* Tested and replaced in all the remaining HOF services
* Fixed vulnerabilities in the image
* Testing in Branch env
* https://collaboration.homeoffice.gov.uk/jira/browse/EPP-282

## Why?

* Large number of Critical and High CVE Vulnerabilities have been detected by Trivy Scan
* Node image v18 is outdated. HOF is moving to v20 and v22 in future Goals.

## How?

* Replace html-pdf-converter image with latest
* Add a comment to explain the version and Date.


## Testing?
* Regression testing in Branch and then merge to master to deploy and test in UAT, Stage and promote to Prod
* Check boxes will ticked as we pass through each env
- [ ] Branch
- [ ] UAT
- [ ] Stage
- [ ] Prod

## Screenshots (optional)

<img width="1184" alt="image" src="https://github.com/user-attachments/assets/d54c50cd-d7c7-45de-9eb8-33292b0ac40f" />


## Anything Else? (optional)
* Drone build is successful
* Pods are Healthy
* Staging environment has been commented out in pipeline 4 years ago by team

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
