### PR TITLE
EPP-297 bug fix all journeys

### DIFF
--- a/apps/epp-amend/translations/src/en/fields.json
+++ b/apps/epp-amend/translations/src/en/fields.json
@@ -158,6 +158,17 @@
       }
     }
   },
+  "amend-regulated-explosives-precursors": {
+    "legend": "Do you need to amend the explosives precursors on your licence?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
   "precursor-field": {
     "hint": "Select an explosives precursor",
     "options":{
@@ -166,6 +177,56 @@
   },
   "selected-precursor-title":{
     "joinTitle" : "{{values.selectedPrecursorShortTitle}}"
+  },
+  "why-need-precursor":{
+    "label": "{{values.whyNeedPrecursorLabel}}",
+    "hint": "Detailed answers mean we can process your application faster",
+    "summary-heading": "Why do you need it?"
+  },
+  "how-much-precursor":{
+    "label": "How much do you wish to acquire at any one time within a 6-month period?",
+    "hint": "Enter the amount and the unit. For example, 10 litres",
+    "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
+  },
+  "what-concentration-precursor":{
+    "label": "What concentration % w/w of the substance do you need?",
+    "summary-heading": "What concentration % w/w of the substance do you need?"
+  },
+  "where-to-store-precursor": {
+    "legend": "{{values.whereToStorePrecursorLegend}}",
+    "summary-heading": "Where it will be stored?",
+    "hint": "This must be in the UK",
+    "options": {
+      "store-precursors-home-address-value": {
+        "label": "{{values.homeAddressInline}}",
+        "summary-heading": "{{values.homeAddressInline}}"
+      },
+      "store-precursors-other-address-value": {
+        "label": "Other address"
+      }
+    }
+  },
+  "store-precursors-other-address": {
+    "label": "{{values.storePrecursorOtherAddressLabel}}",
+    "hint": "Enter a UK address"
+  },
+  "where-to-use-precursor": {
+    "legend": "{{values.whereToUsePrecursorLegend}}",
+    "hint": "This must be in the UK",
+    "summary-heading": "Where it will be used?",
+    "options": {
+      "use-precursors-home-address-value": {
+        "label": "{{values.homeAddressInline}}",
+        "summary-heading": "{{values.homeAddressInline}}"
+      },
+      "use-precursors-other-address-value": {
+        "label": "Other address"
+      }
+    }
+  },
+  "precursors-use-other-address": {
+    "label": "{{values.usePrecursorOtherAddressLabel}}",
+    "hint": "Enter a UK address"
   },
   "amend-poisons-option": {
     "legend":"Does your licence need to cover poisons?",
@@ -184,6 +245,61 @@
         "none_selected": "Select poison"
     }
   },
+  "selected-poison-title":{
+    "joinTitle" : "{{values.selectedPoisonShortTitle}}"
+  },
+  "why-need-poison":{
+    "label": "{{values.whyNeedPoisonLabel}}",
+    "hint": "Detailed answers mean we can process your application faster",
+    "summary-heading": "Why do you need it?"
+  },
+  "how-much-poison":{
+    "label": "How much do you wish to acquire at any one time within a 6-month period?",
+    "hint": "Enter the amount and the unit. For example, 10 litres",
+    "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
+  },
+  "compound-or-salt": {
+    "label": "Specific compound or salt",
+    "summary-heading": "Specific compound or salt"
+  },
+  "what-concentration-poison":{
+    "label": "What concentration % w/w of the substance do you need?",
+    "summary-heading": "What concentration % w/w of the substance do you need?"
+  },
+  "where-to-store-poison": {
+    "legend": "{{values.whereToStorePoisonLegend}}",
+    "hint": "This must be in the UK",
+    "summary-heading": "Where it will be stored?",
+    "options": {
+      "store-poison-home-address-value": {
+        "label": "{{values.homeAddressInline}}"
+      },
+      "store-poison-other-address-value": {
+        "label": "Other address"
+      }
+    }
+  },
+  "store-poison-other-address": {
+    "label": "{{values.storePoisonOtherAddressLabel}}",
+    "hint": "Enter a UK address"
+  },
+  "where-to-use-poison": {
+    "legend": "{{values.whereToUsePoisonLegend}}",
+    "hint": "This must be in the UK",
+    "summary-heading": "Where it will be used?",
+    "options": {
+      "use-poison-home-address": {
+        "label": "{{values.homeAddressInline}}"
+      },
+      "use-poison-other-address-value": {
+        "label": "Other address"
+      }
+    }
+  },
+  "poison-use-other-address": {
+    "label": "{{values.usePoisonOtherAddressLabel}}",
+    "hint": "Enter a UK address"
+  },
   "amend-no-poisons-precursors-options": {
     "legend":"Do you want to continue the form without changing the explosives precursors or poisons?",
     "options": {
@@ -192,6 +308,22 @@
       },
       "no": {
         "label": "No"
+      }
+    }
+  },
+  "amend-countersignatory-Id-type": {
+    "legend": "What is your countersignatory’s identity document?",
+    "hint": "You only need to provide a document number.",
+    "options": {
+      "UK-passport": {
+        "label": "British passport"
+      },
+      "EU-passport": {
+        "label": "Passport from the EU, Switzerland, Norway, Iceland or Liechtenstein"
+      },
+      "Uk-driving-licence": {
+        "label": "UK driving licence",
+        "hint": "Must be a photocard licence."
       }
     }
   },
@@ -241,135 +373,6 @@
   },
   "amend-countersignatory-email": {
     "label": "Email address"
-  },
-  "amend-regulated-explosives-precursors": {
-    "legend": "Do you need to amend the explosives precursors on your licence?",
-    "options": {
-      "yes": {
-        "label": "Yes"
-      },
-      "no": {
-        "label": "No"
-      }
-    }
-  },
-  "why-need-precursor":{
-    "label": "{{values.whyNeedPrecursorLabel}}",
-    "hint": "Detailed answers mean we can process your application faster",
-    "summary-heading": "{{values.whyNeedPrecursorLabel}}"
-  },
-  "how-much-precursor":{
-    "label": "How much do you wish to acquire at any one time within a 6-month period?",
-    "hint": "Enter the amount and the unit. For example, 10 litres",
-    "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
-  },
-  "what-concentration-precursor":{
-    "label": "What concentration % w/w of the substance do you need?",
-    "summary-heading": "What concentration % w/w of the substance do you need?"
-  },
-  "where-to-store-precursor": {
-    "legend": "{{values.whereToStorePrecursorLegend}}",
-    "summary-heading": "{{values.whereToStorePrecursorLegend}}",
-    "hint": "This must be in the UK",
-    "options": {
-      "store-precursors-home-address-value": {
-        "label": "{{values.homeAddressInline}}",
-        "summary-heading": "{{values.homeAddressInline}}"
-      },
-      "store-precursors-other-address-value": {
-        "label": "Other address"
-      }
-    }
-  },
-  "store-precursors-other-address": {
-    "label": "{{values.storePrecursorOtherAddressLabel}}",
-    "hint": "Enter a UK address"
-  },
-  "where-to-use-precursor": {
-    "legend": "{{values.whereToUsePrecursorLegend}}",
-    "hint": "This must be in the UK",
-    "summary-heading": "{{values.whereToUsePrecursorLegend}}",
-    "options": {
-      "use-precursors-home-address-value": {
-        "label": "{{values.homeAddressInline}}",
-        "summary-heading": "{{values.homeAddressInline}}"
-      },
-      "use-precursors-other-address-value": {
-        "label": "Other address"
-      }
-    }
-  },
-  "precursors-use-other-address": {
-    "label": "{{values.usePrecursorOtherAddressLabel}}",
-    "hint": "Enter a UK address"
-  },
-  "why-need-poison":{
-    "label": "{{values.whyNeedPoisonLabel}}",
-    "hint": "Detailed answers mean we can process your application faster",
-    "summary-heading": "{{values.whyNeedPoisonLabel}}"
-  },
-  "how-much-poison":{
-    "label": "How much do you wish to acquire at any one time within a 6-month period?",
-    "hint": "Enter the amount and the unit. For example, 10 litres",
-    "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
-  },
-  "compound-or-salt": {
-    "label": "Specific compound or salt",
-    "summary-heading": "Specific compound or salt"
-  },
-  "what-concentration-poison":{
-    "label": "What concentration % w/w of the substance do you need?",
-    "summary-heading": "What concentration % w/w of the substance do you need?"
-  },
-  "where-to-store-poison": {
-    "legend": "{{values.whereToStorePoisonLegend}}",
-    "hint": "This must be in the UK",
-    "summary-heading": "{{values.whereToStorePoisonLegend}}",
-    "options": {
-      "store-poison-home-address-value": {
-        "label": "{{values.homeAddressInline}}"
-      },
-      "store-poison-other-address-value": {
-        "label": "Other address"
-      }
-    }
-  },
-  "store-poison-other-address": {
-    "label": "{{values.storePoisonOtherAddressLabel}}",
-    "hint": "Enter a UK address"
-  },
-  "where-to-use-poison": {
-    "legend": "{{values.whereToUsePoisonLegend}}",
-    "hint": "This must be in the UK",
-    "summary-heading": "{{values.whereToUsePoisonLegend}}",
-    "options": {
-      "use-poison-home-address": {
-        "label": "{{values.homeAddressInline}}"
-      },
-      "use-poison-other-address-value": {
-        "label": "Other address"
-      }
-    }
-  },
-  "poison-use-other-address": {
-    "label": "{{values.usePoisonOtherAddressLabel}}",
-    "hint": "Enter a UK address"
-  },
-  "amend-countersignatory-Id-type": {
-    "legend": "What is your countersignatory’s identity document?",
-    "hint": "You only need to provide a document number.",
-    "options": {
-      "UK-passport": {
-        "label": "British passport"
-      },
-      "EU-passport": {
-        "label": "Passport from the EU, Switzerland, Norway, Iceland or Liechtenstein"
-      },
-      "Uk-driving-licence": {
-        "label": "UK driving licence",
-        "hint": "Must be a photocard licence."
-      }
-    }
   },
   "amend-countersignatory-UK-passport-number": {
     "label": "What is your passport number?",

--- a/apps/epp-new/translations/src/en/fields.json
+++ b/apps/epp-new/translations/src/en/fields.json
@@ -292,6 +292,199 @@
     "hint": "For example, 30 10 2014",
     "summary-heading": "When did you move to this address?"
   },
+  "new-renew-licence-type": {
+    "legend": "Licence type",
+    "summary-heading": "Licence type"
+  },
+  "new-renew-why-licence-refused": {
+    "label": "Why was the licence refused or revoked?",
+    "summary-heading": "Why the licence was refused or revoked"
+  },
+  "new-renew-licence-refused-date": {
+    "legend": "Date the licence was refused or revoked",
+    "hint": "Enter an approximate date if you are unsure",
+    "summary-heading": "Date the licence was refused or revoked"
+  },
+  "new-renew-offence-name": {
+    "label": "Name of offence",
+    "summary-heading": "Name of offence"
+  },
+  "new-renew-offence-country": {
+    "label": "Which country was the offence committed in?",
+    "hint": "Select a country from the list",
+    "options": {
+      "none_selected": "Select"
+    },
+    "summary-heading": "Country"
+  },
+  "new-renew-offence-date": {
+    "legend": "When did the offence happen?",
+    "hint": "If you do not know, enter an approximate date. For example, 21 3 2017",
+    "summary-heading": "When offence happened"
+  },
+  "new-renew-doctor-name": {
+    "label": "Your doctor’s name",
+    "hint": "If you do not have a specific doctor, enter the name of the medical practice"
+  },
+  "new-renew-doctor-address-line-1": {
+    "label": "Address line 1"
+  },
+  "new-renew-doctor-address-line-2": {
+    "label": "Address line 2 (optional)"
+  },
+  "new-renew-doctor-town-city": {
+    "label": "Town or city"
+  },
+  "new-renew-doctor-county": {
+    "label": "County, state, province (optional)"
+  },
+  "new-renew-doctor-postcode": {
+    "label": "Postcode (optional)",
+    "hint": "Postcode is optional if the address is outside the UK"
+  },
+  "new-renew-doctor-country": {
+    "label": "Country of address",
+    "hint": "Select a country from the list",
+    "options": {
+      "none_selected": "Select"
+    }
+  },
+  "new-renew-regulated-explosives-precursors-options": {
+    "legend":"Does your licence need to cover explosives precursors?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "precursor-field": {
+    "hint": "Select an explosives precursor",
+    "options":{
+      "none_selected": "Select"
+    }
+  },
+  "why-need-precursor":{
+    "label": "{{values.whyNeedPrecursorLabel}}",
+    "hint": "Detailed answers mean we can process your application faster",
+    "summary-heading": "Why do you need it?"
+  },
+  "how-much-precursor":{
+    "label": "How much do you wish to acquire at any one time within a 6-month period?",
+    "hint": "Enter the amount and the unit. For example, 10 litres",
+    "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
+  },
+  "what-concentration-precursor":{
+    "label": "What concentration % w/w of the substance do you need?",
+    "summary-heading": "What concentration % w/w of the substance do you need?"
+  },
+  "where-to-store-precursor": {
+    "legend": "{{values.whereToStorePrecursorLegend}}",
+    "summary-heading": "Where it will be stored?",
+    "hint": "This must be in the UK",
+    "options": {
+      "store-precursors-home-address-value": {
+        "label": "{{values.homeAddressInline}}",
+        "summary-heading": "{{values.homeAddressInline}}"
+      },
+      "store-precursors-other-address-value": {
+        "label": "Other address"
+      }
+    }
+  },
+  "store-precursors-other-address": {
+    "label": "{{values.storePrecursorOtherAddressLabel}}",
+    "hint": "Enter a UK address"
+  },
+  "where-to-use-precursor": {
+    "legend": "{{values.whereToUsePrecursorLegend}}",
+    "hint": "This must be in the UK",
+    "summary-heading": "Where it will be used?",
+    "options": {
+      "use-precursors-home-address-value": {
+        "label": "{{values.homeAddressInline}}",
+        "summary-heading": "{{values.homeAddressInline}}"
+      },
+      "use-precursors-other-address-value": {
+        "label": "Other address"
+      }
+    }
+  },
+  "precursors-use-other-address": {
+    "label": "{{values.usePrecursorOtherAddressLabel}}",
+    "hint": "Enter a UK address"
+  },
+  "new-renew-poisons-options": {
+    "legend":"Does your licence need to cover poisons?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "poison-field": {
+    "hint": "Select a poison",
+      "options":{
+        "none_selected": "Select poison"
+    }
+  },
+  "why-need-poison":{
+    "label": "{{values.whyNeedPoisonLabel}}",
+    "hint": "Detailed answers mean we can process your application faster",
+    "summary-heading": "Why do you need it?"
+  },
+  "how-much-poison":{
+    "label": "How much do you wish to acquire at any one time within a 6-month period?",
+    "hint": "Enter the amount and the unit. For example, 10 litres",
+    "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
+  },
+  "compound-or-salt": {
+    "label": "Specific compound or salt",
+    "summary-heading": "Specific compound or salt"
+  },
+  "what-concentration-poison":{
+    "label": "What concentration % w/w of the substance do you need?",
+    "summary-heading": "What concentration % w/w of the substance do you need?"
+  },
+  "where-to-store-poison": {
+    "legend": "{{values.whereToStorePoisonLegend}}",
+    "hint": "This must be in the UK",
+    "summary-heading": "Where it will be stored?",
+    "options": {
+      "store-poison-home-address-value": {
+        "label": "{{values.homeAddressInline}}"
+      },
+      "store-poison-other-address-value": {
+        "label": "Other address"
+      }
+    }
+  },
+  "store-poison-other-address": {
+    "label": "{{values.storePoisonOtherAddressLabel}}",
+    "hint": "Enter a UK address"
+  },
+  "where-to-use-poison": {
+    "legend": "{{values.whereToUsePoisonLegend}}",
+    "hint": "This must be in the UK",
+    "summary-heading": "Where it will be used?",
+    "options": {
+      "use-poison-home-address": {
+        "label": "{{values.homeAddressInline}}"
+      },
+      "use-poison-other-address-value": {
+        "label": "Other address"
+      }
+    }
+  },
+  "poison-use-other-address": {
+    "label": "{{values.usePoisonOtherAddressLabel}}",
+    "hint": "Enter a UK address"
+  },
   "new-renew-countersignatory-title":{
     "label": "Title",
     "options": {
@@ -339,39 +532,6 @@
   "new-renew-countersignatory-email": {
     "label": "Email address"
   },
-  "new-renew-declaration": {
-    "label": "I have read and agree to this declaration"
-  },
-  "new-renew-licence-type": {
-    "legend": "Licence type",
-    "summary-heading": "Licence type"
-  },
-  "new-renew-why-licence-refused": {
-    "label": "Why was the licence refused or revoked?",
-    "summary-heading": "Why the licence was refused or revoked"
-  },
-  "new-renew-licence-refused-date": {
-    "legend": "Date the licence was refused or revoked",
-    "hint": "Enter an approximate date if you are unsure",
-    "summary-heading": "Date the licence was refused or revoked"
-  },
-  "new-renew-offence-name": {
-    "label": "Name of offence",
-    "summary-heading": "Name of offence"
-  },
-  "new-renew-offence-country": {
-    "label": "Which country was the offence committed in?",
-    "hint": "Select a country from the list",
-    "options": {
-      "none_selected": "Select"
-    },
-    "summary-heading": "Country"
-  },
-  "new-renew-offence-date": {
-    "legend": "When did the offence happen?",
-    "hint": "If you do not know, enter an approximate date. For example, 21 3 2017",
-    "summary-heading": "When offence happened"
-  },
   "new-renew-countersignatory-Id-type": {
     "legend": "What is your countersignatory's identity document?",
     "hint": "If your licence is granted, you will need to show this document when buying the substances",
@@ -400,167 +560,7 @@
     "label": "What is your driving licence number?",
     "hint" : "On section 5 of your licence, for example MORGA657054SM9IJ"
   },
-  "new-renew-doctor-name": {
-    "label": "Your doctor’s name",
-    "hint": "If you do not have a specific doctor, enter the name of the medical practice"
-  },
-  "new-renew-doctor-address-line-1": {
-    "label": "Address line 1"
-  },
-  "new-renew-doctor-address-line-2": {
-    "label": "Address line 2 (optional)"
-  },
-  "new-renew-doctor-town-city": {
-    "label": "Town or city"
-  },
-  "new-renew-doctor-county": {
-    "label": "County, state, province (optional)"
-  },
-  "new-renew-doctor-postcode": {
-    "label": "Postcode (optional)",
-    "hint": "Postcode is optional if the address is outside the UK"
-  },
-  "new-renew-doctor-country": {
-    "label": "Country of address",
-    "hint": "Select a country from the list",
-    "options": {
-      "none_selected": "Select"
-    }
-  },
-  "precursor-field": {
-    "hint": "Select an explosives precursor",
-    "options":{
-      "none_selected": "Select"
-    }
-  },
-  "new-renew-poisons-options": {
-    "legend":"Does your licence need to cover poisons?",
-    "options": {
-      "yes": {
-        "label": "Yes"
-      },
-      "no": {
-        "label": "No"
-      }
-    }
-  },
-  "poison-field": {
-    "hint": "Select a poison",
-      "options":{
-        "none_selected": "Select poison"
-    }
-  },
-  "why-need-precursor":{
-    "label": "{{values.whyNeedPrecursorLabel}}",
-    "hint": "Detailed answers mean we can process your application faster",
-    "summary-heading": "{{values.whyNeedPrecursorLabel}}"
-  },
-  "how-much-precursor":{
-    "label": "How much do you wish to acquire at any one time within a 6-month period?",
-    "hint": "Enter the amount and the unit. For example, 10 litres",
-    "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
-  },
-  "what-concentration-precursor":{
-    "label": "What concentration % w/w of the substance do you need?",
-    "summary-heading": "What concentration % w/w of the substance do you need?"
-  },
-  "where-to-store-precursor": {
-    "legend": "{{values.whereToStorePrecursorLegend}}",
-    "summary-heading": "{{values.whereToStorePrecursorLegend}}",
-    "hint": "This must be in the UK",
-    "options": {
-      "store-precursors-home-address-value": {
-        "label": "{{values.homeAddressInline}}",
-        "summary-heading": "{{values.homeAddressInline}}"
-      },
-      "store-precursors-other-address-value": {
-        "label": "Other address"
-      }
-    }
-  },
-  "store-precursors-other-address": {
-    "label": "{{values.storePrecursorOtherAddressLabel}}",
-    "hint": "Enter a UK address"
-  },
-  "where-to-use-precursor": {
-    "legend": "{{values.whereToUsePrecursorLegend}}",
-    "hint": "This must be in the UK",
-    "summary-heading": "{{values.whereToUsePrecursorLegend}}",
-    "options": {
-      "use-precursors-home-address-value": {
-        "label": "{{values.homeAddressInline}}",
-        "summary-heading": "{{values.homeAddressInline}}"
-      },
-      "use-precursors-other-address-value": {
-        "label": "Other address"
-      }
-    }
-  },
-  "precursors-use-other-address": {
-    "label": "{{values.usePrecursorOtherAddressLabel}}",
-    "hint": "Enter a UK address"
-  },
-  "why-need-poison":{
-    "label": "{{values.whyNeedPoisonLabel}}",
-    "hint": "Detailed answers mean we can process your application faster",
-    "summary-heading": "{{values.whyNeedPoisonLabel}}"
-  },
-  "how-much-poison":{
-    "label": "How much do you wish to acquire at any one time within a 6-month period?",
-    "hint": "Enter the amount and the unit. For example, 10 litres",
-    "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
-  },
-  "compound-or-salt": {
-    "label": "Specific compound or salt",
-    "summary-heading": "Specific compound or salt"
-  },
-  "what-concentration-poison":{
-    "label": "What concentration % w/w of the substance do you need?",
-    "summary-heading": "What concentration % w/w of the substance do you need?"
-  },
-  "where-to-store-poison": {
-    "legend": "{{values.whereToStorePoisonLegend}}",
-    "hint": "This must be in the UK",
-    "summary-heading": "{{values.whereToStorePoisonLegend}}",
-    "options": {
-      "store-poison-home-address-value": {
-        "label": "{{values.homeAddressInline}}"
-      },
-      "store-poison-other-address-value": {
-        "label": "Other address"
-      }
-    }
-  },
-  "store-poison-other-address": {
-    "label": "{{values.storePoisonOtherAddressLabel}}",
-    "hint": "Enter a UK address"
-  },
-  "where-to-use-poison": {
-    "legend": "{{values.whereToUsePoisonLegend}}",
-    "hint": "This must be in the UK",
-    "summary-heading": "{{values.whereToUsePoisonLegend}}",
-    "options": {
-      "use-poison-home-address": {
-        "label": "{{values.homeAddressInline}}"
-      },
-      "use-poison-other-address-value": {
-        "label": "Other address"
-      }
-    }
-  },
-  "poison-use-other-address": {
-    "label": "{{values.usePoisonOtherAddressLabel}}",
-    "hint": "Enter a UK address"
-  },
-  "new-renew-regulated-explosives-precursors-options": {
-    "legend":"Does your licence need to cover explosives precursors?",
-    "options": {
-      "yes": {
-        "label": "Yes"
-      },
-      "no": {
-        "label": "No"
-      }
-    }
+  "new-renew-declaration": {
+    "label": "I have read and agree to this declaration"
   }
 }

--- a/apps/epp-replace/translations/src/en/fields.json
+++ b/apps/epp-replace/translations/src/en/fields.json
@@ -1,102 +1,4 @@
 {
-  "replace-licence-number": {
-    "label": "Enter your licence number (optional)",
-    "hint": "For example 95/W/000000/2024"
-  },
-  "replace-title": {
-    "label": "Title",
-    "options": {
-      "none_selected": "Select"
-    }
-  },
-      "replace-new-name-title": {
-        "label": "Title",
-        "options": {
-          "none_selected": "Select"
-        }
-      },
-      "replace-home-address-options": {
-        "legend": "Do you need to amend your home address on the licence?",
-        "options": {
-          "yes": {
-            "label": "Yes"
-          },
-          "no": {
-            "label": "No"
-          }
-        }
-      },
-      "replace-new-firstname": {
-        "label": "First name"
-      },
-      "replace-new-middlename": {
-        "label": "Middle names (optional)"
-      },
-      "replace-new-lastname": {
-        "label": "Last name"
-      },
-      "replace-date-new-name-changed": {
-        "legend": "What date did you change your name?",
-        "hint": "For example, 30 09 2014"
-      },
-  "replace-first-name": {
-    "label": "First name"
-  },
-  "replace-middle-name": {
-    "label": "Middle names (optional)"
-  },
-  "replace-last-name": {
-    "label": "Last name"
-  },
-  "replace-police-report": {
-    "legend": "Have you reported the theft to the police?",
-    "options": {
-      "yes": {
-        "label": "Yes"
-      },
-      "no": {
-        "label": "No"
-      }
-    }
-  },
-      "replace-new-address-1": {
-        "label": "Address line 1"
-      },
-      "replace-new-address-2": {
-        "label": "Address line 2 (optional)"
-      },
-      "replace-new-town-or-city": {
-        "label": "Town or city"
-      },
-      "replace-new-county": {
-        "label": "County, state, province (optional)"
-      },
-      "replace-new-postcode": {
-        "label": "Postcode (optional)",
-        "hint": "Postcode is optional if your address is outside the UK"
-      },
-      "replace-new-country": {
-        "label": "Country of address",
-        "hint": "Select a country from the list",
-        "options": {
-          "none_selected": "Select"
-        }
-      },
-      "replace-change-substances": {
-        "legend": "Do you need to amend the substances on your licence?",
-        "options": {
-          "yes": {
-            "label": "Yes"
-          },
-          "no": {
-            "label": "No"
-          }
-        }
-      },
-      "replace-new-date-moved-to-address": {
-          "legend": "When did you move to this address?",
-          "hint": " For example, 30 09 1969"
-      },
   "replace-licence": {
     "legend": "Why do you need a replacement licence?",
     "options": {
@@ -114,9 +16,269 @@
       }
     }
   },
+  "replace-police-report": {
+    "legend": "Have you reported the theft to the police?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "replace-police-force": {
+    "label": "Which police force did you report this to?",
+    "hint": "Select a police force from the list",
+    "options": {
+      "none_selected": "Select"
+    }
+  },
+  "replace-crime-number": {
+    "label": "Crime number"
+  },
+  "replace-licence-number": {
+    "label": "Enter your licence number (optional)",
+    "hint": "For example 95/W/000000/2024"
+  },
+  "replace-title": {
+    "label": "Title",
+    "options": {
+      "none_selected": "Select"
+    }
+  },
+  "replace-first-name": {
+    "label": "First name"
+  },
+  "replace-middle-name": {
+    "label": "Middle names (optional)"
+  },
+  "replace-last-name": {
+    "label": "Last name"
+  },
+  "replace-date-of-birth": {
+    "hint": " For example, 30 09 1969",
+    "label": "Date of birth"
+  },
+  "replace-home-address-1": {
+    "label": "Address line 1"
+  },
+  "replace-home-address-2": {
+    "label": "Address line 2 (optional)"
+  },
+  "replace-home-town-or-city": {
+    "label": "Town or city"
+  },
+  "replace-home-county": {
+    "label": "County, state, province (optional)"
+  },
+  "replace-home-postcode": {
+    "label": "Postcode (optional)",
+    "hint": "Postcode is optional if your address is outside the UK"
+  },
+  "replace-home-country": {
+    "label": "Country of address",
+    "hint": "Select a country from the list",
+    "options": {
+      "none_selected": "Select"
+    }
+  },
+  "replace-phone-number": {
+    "label": "Contact phone number",
+    "hint": "For international numbers, include the country code"
+  },
+  "replace-email": {
+    "label": "Email address",
+    "hint": "Where we will contact you about the outcome of your application"
+  },
   "replace-is-details-changed": {
     "legend": "Have any of your details changed since the licence was issued?",
     "hint": "Includes the name, address and substances recorded on the licence",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+"replace-name-options": {
+  "legend": "Do you need to amend your name on the licence?",
+  "options": {
+    "yes": {
+      "label": "Yes"
+    },
+    "no": {
+      "label": "No"
+    }
+  }
+},
+"replace-new-name-title": {
+  "label": "Title",
+  "options": {
+    "none_selected": "Select"
+  }
+},
+"replace-new-firstname": {
+    "label": "First name"
+  },
+  "replace-new-middlename": {
+    "label": "Middle names (optional)"
+  },
+  "replace-new-lastname": {
+    "label": "Last name"
+  },
+  "replace-date-new-name-changed": {
+    "legend": "What date did you change your name?",
+    "hint": "For example, 30 09 2014"
+  },
+  "replace-which-document-type": {
+    "legend": "Which identity document do you want to use?",
+    "hint": "If your licence is granted, you will need to show this document when buying the substances",
+    "options": {
+      "UK-passport": {
+        "label": "British passport"
+      },
+      "EU-passport": {
+        "label": "Passport from the EU, Switzerland, Norway, Iceland or Liechtenstein"
+      },
+      "Uk-driving-licence": {
+        "label": "UK driving licence",
+        "hint": "Must be a photocard licence."
+      }
+    }
+  },
+  "replace-UK-passport-number": {
+    "label": "What is your passport number?",
+    "hint": "For example, 120897A"
+  },
+  "replace-EU-passport-number": {
+    "label": "What is your passport number?",
+    "hint": "For example, 120897A"
+  },
+  "replace-Uk-driving-licence-number": {
+    "label": "What is your driving licence number?",
+    "hint": "On section 5 of your licence, for example MORGA657054SM9IJ"
+  },
+"replace-home-address-options": {
+  "legend": "Do you need to amend your home address on the licence?",
+  "options": {
+    "yes": {
+      "label": "Yes"
+    },
+    "no": {
+      "label": "No"
+    }
+  }
+},
+"replace-new-address-1": {
+  "label": "Address line 1"
+},
+"replace-new-address-2": {
+  "label": "Address line 2 (optional)"
+},
+"replace-new-town-or-city": {
+  "label": "Town or city"
+},
+"replace-new-county": {
+  "label": "County, state, province (optional)"
+},
+"replace-new-postcode": {
+  "label": "Postcode (optional)",
+  "hint": "Postcode is optional if your address is outside the UK"
+},
+"replace-new-country": {
+  "label": "Country of address",
+  "hint": "Select a country from the list",
+  "options": {
+    "none_selected": "Select"
+  }
+},
+"replace-new-date-moved-to-address": {
+  "legend": "When did you move to this address?",
+  "hint": " For example, 30 09 1969"
+},
+"replace-change-substances": {
+  "legend": "Do you need to amend the substances on your licence?",
+  "options": {
+    "yes": {
+      "label": "Yes"
+    },
+    "no": {
+      "label": "No"
+    }
+  }
+},
+"replace-regulated-explosives-precursors": {
+  "legend": "Do you need to amend the explosives precursors on your licence?",
+  "options": {
+    "yes": {
+      "label": "Yes"
+    },
+    "no": {
+      "label": "No"
+    }
+  }
+},
+"precursor-field": {
+  "hint": "Select an explosives precursor",
+  "options": {
+    "none_selected": "Select"
+  }
+},
+"why-need-precursor": {
+  "label": "{{values.whyNeedPrecursorLabel}}",
+  "hint": "Detailed answers mean we can process your application faster",
+  "summary-heading": "Why do you need it?"
+},
+"how-much-precursor": {
+  "label": "How much do you wish to acquire at any one time within a 6-month period?",
+  "hint": "Enter the amount and the unit. For example, 10 litres",
+  "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
+},
+"what-concentration-precursor": {
+  "label": "What concentration % w/w of the substance do you need?",
+  "summary-heading": "What concentration % w/w of the substance do you need?"
+},
+"where-to-store-precursor": {
+  "legend": "{{values.whereToStorePrecursorLegend}}",
+  "summary-heading": "Where it will be stored?",
+  "hint": "This must be in the UK",
+  "options": {
+    "store-precursors-home-address-value": {
+      "label": "{{values.homeAddressInline}}",
+      "summary-heading": "{{values.homeAddressInline}}"
+    },
+    "store-precursors-other-address-value": {
+      "label": "Other address"
+    }
+  }
+},
+"store-precursors-other-address": {
+  "label": "{{values.storePrecursorOtherAddressLabel}}",
+  "hint": "Enter a UK address"
+},
+"where-to-use-precursor": {
+  "legend": "{{values.whereToUsePrecursorLegend}}",
+  "hint": "This must be in the UK",
+  "summary-heading": "Where it will be used?",
+  "options": {
+    "use-precursors-home-address-value": {
+      "label": "{{values.homeAddressInline}}",
+      "summary-heading": "{{values.homeAddressInline}}"
+    },
+    "use-precursors-other-address-value": {
+      "label": "Other address"
+    }
+  }
+},
+"precursors-use-other-address": {
+  "label": "{{values.usePrecursorOtherAddressLabel}}",
+  "hint": "Enter a UK address"
+},
+"replace-poisons-option": {
+    "legend": "Does your licence need to cover poisons?",
     "options": {
       "yes": {
         "label": "Yes"
@@ -135,12 +297,12 @@
   "why-need-poison": {
     "label": "{{values.whyNeedPoisonLabel}}",
     "hint": "Detailed answers mean we can process your application faster",
-    "summary-heading": "{{values.whyNeedPoisonLabel}}"
+    "summary-heading": "Why do you need it?"
   },
   "how-much-poison": {
     "label": "How much do you wish to acquire at any one time within a 6-month period?",
     "hint": "Enter the amount and the unit. For example, 10 litres",
-     "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
+    "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
   },
   "compound-or-salt": {
     "label": "Specific compound or salt",
@@ -148,11 +310,11 @@
   },
   "what-concentration-poison": {
     "label": "What concentration % w/w of the substance do you need?",
-     "summary-heading": "What concentration % w/w of the substance do you need?"
+    "summary-heading": "What concentration % w/w of the substance do you need?"
   },
   "where-to-store-poison": {
     "legend": "{{values.whereToStorePoisonLegend}}",
-    "summary-heading": "{{values.whereToStorePoisonLegend}}",
+    "summary-heading": "Where it will be stored?",
     "hint": "This must be in the UK",
     "options": {
       "store-poison-home-address-value": {
@@ -171,7 +333,7 @@
   "where-to-use-poison": {
     "legend": "{{values.whereToUsePoisonLegend}}",
     "hint": "This must be in the UK",
-    "summary-heading": "{{values.whereToUsePoisonLegend}}",
+    "summary-heading": "Where it will be used?",
     "options": {
       "use-poison-home-address": {
         "label": "{{values.homeAddressInline}}"
@@ -186,6 +348,13 @@
     "hint": "Enter a UK address",
     "summary-heading": "{{values.usePoisonOtherAddressLabel}}"
   },
+"replace-no-poisons-precursors-options": {
+  "legend": "Do you want to continue the form without changing the explosives precursors or poisons?",
+  "options": {
+    "yes": { "label": "Yes" },
+    "no": { "label": "No" }
+  }
+},
   "replace-countersignatory-title": {
     "label": "Title",
     "options": {
@@ -261,176 +430,7 @@
     "label": "What is your driving licence number?",
     "hint": "On section 5 of your licence, for example MORGA657054SM9IJ"
   },
-  "replace-date-of-birth": {
-    "hint": " For example, 30 09 1969",
-    "label": "Date of birth"
-  },
-  "replace-which-document-type": {
-    "legend": "Which identity document do you want to use?",
-    "hint": "If your licence is granted, you will need to show this document when buying the substances",
-    "options": {
-      "UK-passport": {
-        "label": "British passport"
-      },
-      "EU-passport": {
-        "label": "Passport from the EU, Switzerland, Norway, Iceland or Liechtenstein"
-      },
-      "Uk-driving-licence": {
-        "label": "UK driving licence",
-        "hint": "Must be a photocard licence."
-      }
-    }
-  },
-  "replace-UK-passport-number": {
-    "label": "What is your passport number?",
-    "hint": "For example, 120897A"
-  },
-  "replace-EU-passport-number": {
-    "label": "What is your passport number?",
-    "hint": "For example, 120897A"
-  },
-  "replace-Uk-driving-licence-number": {
-    "label": "What is your driving licence number?",
-    "hint": "On section 5 of your licence, for example MORGA657054SM9IJ"
-  },
-  "replace-phone-number": {
-    "label": "Contact phone number",
-    "hint": "For international numbers, include the country code"
-  },
-  "replace-email": {
-    "label": "Email address",
-    "hint": "Where we will contact you about the outcome of your application"
-  },
-  "replace-police-force": {
-    "label": "Which police force did you report this to?",
-    "hint": "Select a police force from the list",
-    "options": {
-      "none_selected": "Select"
-    }
-  },
-  "replace-crime-number": {
-    "label": "Crime number"
-  },
-  "replace-home-address-1": {
-    "label": "Address line 1"
-  },
-  "replace-home-address-2": {
-    "label": "Address line 2 (optional)"
-  },
-  "replace-home-town-or-city": {
-    "label": "Town or city"
-  },
-  "replace-home-county": {
-    "label": "County, state, province (optional)"
-  },
-  "replace-home-postcode": {
-    "label": "Postcode (optional)",
-    "hint": "Postcode is optional if your address is outside the UK"
-  },
-  "replace-home-country": {
-    "label": "Country of address",
-    "hint": "Select a country from the list",
-    "options": {
-      "none_selected": "Select"
-    }
-  },
   "amend-declaration": {
     "label": "I have read and agree to this declaration"
-  },
-  "precursor-field": {
-    "hint": "Select an explosives precursor",
-    "options":{
-      "none_selected": "Select"
-    }
-  },
-  "replace-no-poisons-precursors-options": {
-    "legend": "Do you want to continue the form without changing the explosives precursors or poisons?",
-    "options": {
-      "yes": { "label": "Yes" },
-      "no": { "label": "No" }
-    }
-  },
-  "replace-name-options": {
-    "legend": "Do you need to amend your name on the licence?",
-    "options": {
-      "yes": {
-        "label": "Yes"
-      },
-      "no": {
-        "label": "No"
-      }
-    }
-  },
-  "replace-regulated-explosives-precursors": {
-    "legend": "Do you need to amend the explosives precursors on your licence?",
-    "options": {
-      "yes": {
-        "label": "Yes"
-      },
-      "no": {
-        "label": "No"
-      }
-    }
-  },
-  "why-need-precursor":{
-    "label": "{{values.whyNeedPrecursorLabel}}",
-    "hint": "Detailed answers mean we can process your application faster",
-    "summary-heading": "{{values.whyNeedPrecursorLabel}}"
-  },
-  "how-much-precursor":{
-    "label": "How much do you wish to acquire at any one time within a 6-month period?",
-    "hint": "Enter the amount and the unit. For example, 10 litres",
-    "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
-  },
-  "what-concentration-precursor":{
-    "label": "What concentration % w/w of the substance do you need?",
-    "summary-heading": "What concentration % w/w of the substance do you need?"
-  },
-  "where-to-store-precursor": {
-    "legend": "{{values.whereToStorePrecursorLegend}}",
-    "summary-heading": "{{values.whereToStorePrecursorLegend}}",
-    "hint": "This must be in the UK",
-    "options": {
-      "store-precursors-home-address-value": {
-        "label": "{{values.homeAddressInline}}",
-        "summary-heading": "{{values.homeAddressInline}}"
-      },
-      "store-precursors-other-address-value": {
-        "label": "Other address"
-      }
-    }
-  },
-  "store-precursors-other-address": {
-    "label": "{{values.storePrecursorOtherAddressLabel}}",
-    "hint": "Enter a UK address"
-  },
-  "where-to-use-precursor": {
-    "legend": "{{values.whereToUsePrecursorLegend}}",
-    "hint": "This must be in the UK",
-    "summary-heading": "{{values.whereToUsePrecursorLegend}}",
-    "options": {
-      "use-precursors-home-address-value": {
-        "label": "{{values.homeAddressInline}}",
-        "summary-heading": "{{values.homeAddressInline}}"
-      },
-      "use-precursors-other-address-value": {
-        "label": "Other address"
-      }
-    }
-  },
-  "precursors-use-other-address": {
-    "label": "{{values.usePrecursorOtherAddressLabel}}",
-    "hint": "Enter a UK address"
-  },
-  "replace-poisons-option": {
-    "legend":"Does your licence need to cover poisons?",
-    "options": {
-      "yes": {
-        "label": "Yes"
-      },
-      "no": {
-        "label": "No"
-      }
-    }
   }
 }


### PR DESCRIPTION
## What? 
Bug fixing as per jira ticket [EPP-297](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-297)
## Why? 
On all journeys, when user is on the mid-summary page, when they add 2 or more items there is a bug which changes the previous item name and matches it with the most recent one added.
## How? 
As per agreement with PM and DM, the labels for mid-summary pages for precursors and poisons are now hard coded.

- tide up `field.json` using the page flow order.
- update amend, replace and new-renew journeys, poisons and precursors  `.summary-heading` for following fields:
  * where-to-use-precursor + poison
  * why-need-precursor + poison
  * where-to-store-precursor + poison
## Testing?
Manual test
## Screenshots (optional)
## Anything Else? (optional)
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
