### PR TITLE
epp-300 bug fix

### DIFF
--- a/apps/epp-amend/behaviours/countersignatory-navigation.js
+++ b/apps/epp-amend/behaviours/countersignatory-navigation.js
@@ -18,15 +18,14 @@ module.exports = currentRoute => superclass =>
 
       if (
         currentRoute === '/poisons' &&
-        req.form.values['amend-poisons-option'] === 'no'
-      ) {
+        req.form.values['amend-poisons-option'] === 'no') {
         if (amendNameOrAddress) {
           return redirectToCountersignatory();
         }
         if (
           noAmendNameOrAddress &&
           req.sessionModel.get('amend-regulated-explosives-precursors') !==
-            'yes'
+          'yes'
         ) {
           return redirectNoPoisonsOrPrecursors();
         }
@@ -47,7 +46,6 @@ module.exports = currentRoute => superclass =>
           return redirectNoDetailsAmend();
         }
       }
-
       return super.saveValues(req, res, next);
     }
   };

--- a/apps/epp-amend/index.js
+++ b/apps/epp-amend/index.js
@@ -297,9 +297,7 @@ module.exports = {
     '/explosives-precursors': {
       behaviours: [
         ResetSectionSummary(
-          [
-            'precursors-details-aggregate'
-          ],
+          ['precursors-details-aggregate'],
           'amend-regulated-explosives-precursors'
         ),
         CheckAndRedirect('amend-regulated-explosives-precursors', [
@@ -366,14 +364,14 @@ module.exports = {
     },
     '/poisons': {
       behaviours: [
-        CheckAndRedirect('amend-poisons-option', [
-          'amend-poisons-option',
-          'amend-regulated-explosives-precursors'
-        ]),
         ResetSectionSummary(
           ['poisons-details-aggregate'],
           'amend-poisons-option'
         ),
+        CheckAndRedirect('amend-poisons-option', [
+          'amend-poisons-option',
+          'amend-regulated-explosives-precursors'
+        ]),
         CounterSignatoryNavigation('/poisons')
       ],
       fields: ['amend-poisons-option'],

--- a/apps/epp-common/behaviours/reset-section-summary.js
+++ b/apps/epp-common/behaviours/reset-section-summary.js
@@ -10,7 +10,7 @@ module.exports = (aggregateToFields, sectionStartField) => superclass =>
         aggregateToFields.forEach(aggregateToField => {
           if (req.sessionModel.get(aggregateToField) !== undefined) {
             if (
-              req.sessionModel.get(sectionStartField) === 'no' &&
+              req.form.values[sectionStartField] === 'no' &&
               req.sessionModel.get(aggregateToField).aggregatedValues.length > 0
             ) {
               req.sessionModel.unset(aggregateToField);

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -560,28 +560,28 @@ module.exports = {
       }
     },
     '/explosives-precursors': {
-      behaviours: [NoPrecursorOrPoison, ResetSectionSummary(
-        ['precursors-details-aggregate'],
-        'new-renew-regulated-explosives-precursors-options')],
+      behaviours: [NoPrecursorOrPoison,
+        ResetSectionSummary(
+          ['precursors-details-aggregate'],
+          'new-renew-regulated-explosives-precursors-options')],
       fields: ['new-renew-regulated-explosives-precursors-options'],
       forks: [
         {
-          target: '/poisons',
-          continueOnEdit: false,
+          target: '/select-precursor',
+          continueOnEdit: true,
           condition: {
             field: 'new-renew-regulated-explosives-precursors-options',
-            value: 'no'
+            value: 'yes'
           }
         }
       ],
-      continueOnEdit: true,
+      next: '/poisons',
       locals: {
         sectionNo: {
           new: 12,
           renew: 13
         }
-      },
-      next: '/select-precursor'
+      }
     },
     '/select-precursor': {
       fields: ['precursor-field'],
@@ -647,22 +647,21 @@ module.exports = {
       fields: ['new-renew-poisons-options'],
       forks: [
         {
-          target: '/countersignatory-details',
-          continueOnEdit: false,
+          target: '/select-poisons',
+          continueOnEdit: true,
           condition: {
             field: 'new-renew-poisons-options',
-            value: 'no'
+            value: 'yes'
           }
         }
       ],
-      continueOnEdit: true,
       locals: {
         sectionNo: {
           new: 14,
           renew: 15
         }
       },
-      next: '/select-poisons'
+      next: '/countersignatory-details'
     },
     '/no-poisons-or-precursors': {
       behaviours: [NoPrecursorPoisonBackLink]

--- a/apps/epp-replace/behaviours/no-precursors-poisons-navigation.js
+++ b/apps/epp-replace/behaviours/no-precursors-poisons-navigation.js
@@ -1,3 +1,4 @@
+
 module.exports = superclass =>
   class extends superclass {
     locals(req, res) {

--- a/apps/epp-replace/behaviours/no-substance-change-navigation.js
+++ b/apps/epp-replace/behaviours/no-substance-change-navigation.js
@@ -1,6 +1,13 @@
 module.exports = route => superclass =>
   class extends superclass {
     successHandler(req, res, next) {
+      const changeNameOrAddress =
+        req.sessionModel.get('replace-name-options') === 'yes' ||
+        req.sessionModel.get('replace-home-address-options') === 'yes';
+      const noChangeNameOrAddress =
+        req.sessionModel.get('replace-name-options') !== 'yes' &&
+        req.sessionModel.get('replace-home-address-options') !== 'yes';
+
       if (
         route === '/poisons' &&
         req.sessionModel.get('replace-poisons-option') === 'no'
@@ -12,19 +19,27 @@ module.exports = route => superclass =>
           req.sessionModel.set('noPrecursorPoisonsBackLink', req.originalUrl);
           return res.redirect(`${req.baseUrl}/no-precursors-or-poisons`);
         }
-
-        const changeNameOrAddress =
-          req.sessionModel.get('replace-name-options') === 'yes' ||
-          req.sessionModel.get('replace-home-address-options') === 'yes';
-
         if (changeNameOrAddress) {
           return res.redirect(`${req.baseUrl}/countersignatory-details`);
         }
-
-        const noChangeNameOrAddress =
-          req.sessionModel.get('replace-name-options') !== 'yes' &&
-          req.sessionModel.get('replace-home-address-options') !== 'yes';
-
+        if (noChangeNameOrAddress) {
+          return res.redirect(`${req.baseUrl}/confirm`);
+        }
+      }
+      if (
+        route === '/explosives-precursors' &&
+        req.sessionModel.get('replace-regulated-explosives-precursors') === 'no'
+      ) {
+        if (
+          req.sessionModel.get('replace-poisons-option') !==
+          'yes'
+        ) {
+          req.sessionModel.set('noPrecursorPoisonsBackLink', req.originalUrl);
+          return res.redirect(`${req.baseUrl}/no-precursors-or-poisons`);
+        }
+        if (changeNameOrAddress) {
+          return res.redirect(`${req.baseUrl}/countersignatory-details`);
+        }
         if (noChangeNameOrAddress) {
           return res.redirect(`${req.baseUrl}/confirm`);
         }

--- a/apps/epp-replace/behaviours/no-substance-change-navigation.js
+++ b/apps/epp-replace/behaviours/no-substance-change-navigation.js
@@ -10,11 +10,10 @@ module.exports = route => superclass =>
 
       if (
         route === '/poisons' &&
-        req.sessionModel.get('replace-poisons-option') === 'no'
-      ) {
+        req.sessionModel.get('replace-poisons-option') === 'no') {
         if (
-          req.sessionModel.get('replace-regulated-explosives-precursors') !==
-          'yes'
+          req.sessionModel.get('replace-regulated-explosives-precursors') ===
+          'no'
         ) {
           req.sessionModel.set('noPrecursorPoisonsBackLink', req.originalUrl);
           return res.redirect(`${req.baseUrl}/no-precursors-or-poisons`);
@@ -25,14 +24,12 @@ module.exports = route => superclass =>
         if (noChangeNameOrAddress) {
           return res.redirect(`${req.baseUrl}/confirm`);
         }
-      }
-      if (
+      } else if (
         route === '/explosives-precursors' &&
         req.sessionModel.get('replace-regulated-explosives-precursors') === 'no'
       ) {
         if (
-          req.sessionModel.get('replace-poisons-option') !==
-          'yes'
+          req.sessionModel.get('replace-poisons-option') === 'no'
         ) {
           req.sessionModel.set('noPrecursorPoisonsBackLink', req.originalUrl);
           return res.redirect(`${req.baseUrl}/no-precursors-or-poisons`);

--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -357,7 +357,7 @@ module.exports = {
       behaviours: [
         NavigateNoChanges,
         ResetSectionSummary(
-          ['poisons-details-aggregate'],
+          ['poisons-details-aggregate', 'precursors-details-aggregate'],
           'replace-change-substances'
         )
       ],
@@ -381,11 +381,12 @@ module.exports = {
       ]
     },
     '/explosives-precursors': {
-      behaviour: [
+      behaviours: [
         ResetSectionSummary(
           ['precursors-details-aggregate'],
           'replace-regulated-explosives-precursors'
-        )
+        ),
+        NoSubstanceChangeNavigation('/explosives-precursors')
       ],
       fields: ['replace-regulated-explosives-precursors'],
       forks: [

--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -465,11 +465,22 @@ module.exports = {
         )
       ],
       fields: ['replace-poisons-option'],
-      next: '/select-poisons',
+      forks: [
+        {
+          target: '/select-poisons',
+          continueOnEdit: true,
+          condition: {
+            field: 'replace-poisons-option',
+            value: 'yes'
+          }
+        }
+      ],
+      next: '/countersignatory-details',
       locals: { captionHeading: 'Section 19 of 26' }
     },
     '/select-poisons': {
       fields: ['poison-field'],
+      continueOnEdit: true,
       next: '/poison-details',
       locals: { captionHeading: 'Section 20 of 26' }
     },

--- a/test/unit/behaviours/reset-section-summary.spec.js
+++ b/test/unit/behaviours/reset-section-summary.spec.js
@@ -42,27 +42,27 @@ describe('reset-section-summary behaviour tests', () => {
       )(Base))();
     });
 
-    it(
-      'should unset aggregateToField if sectionStartField is "no" ' +
+    it('should unset aggregateToField if sectionStartField is "no" ' +
         'and aggregatedValues length is greater than 0',
-      () => {
-        req.sessionModel.get.withArgs('sectionStartField').returns('no');
-        req.sessionModel.get
-          .withArgs('aggregateToField')
-          .returns({ aggregatedValues: [1, 2, 3] });
+    () => {
+      req.form.values = {
+        sectionStartField: 'no'
+      };
+      req.sessionModel.get
+        .withArgs('aggregateToField')
+        .returns({ aggregatedValues: [1, 2, 3] });
 
-        instance.saveValues(req, res, next);
+      instance.saveValues(req, res, next);
 
-        expect(req.sessionModel.unset.calledWith('aggregateToField')).to.be
-          .true;
-        sinon.assert.calledWithExactly(
-          Base.prototype.saveValues,
-          req,
-          res,
-          next
-        );
-      }
-    );
+      expect(req.sessionModel.unset.calledWith('aggregateToField')).to.be
+        .true;
+      sinon.assert.calledWithExactly(
+        Base.prototype.saveValues,
+        req,
+        res,
+        next
+      );
+    });
 
     it('should not unset aggregateToField if sectionStartField is not "no"', () => {
       req.form.values = {


### PR DESCRIPTION
## What? 
Bug fix as per jira ticket [EPP-300](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-300)
## Why? 
On the check your answers page for the replace flow, when the user has previous answer yes to explosive precursors and filled in the corresponding information, when they change the answer to no then the information on EP should be removed. However, the information regarding EP is not removed from the check your answers page.
## How? 
Update : 
reset-section-summary behaviour and related unit test
## Testing?
updated
## Screenshots (optional)
## Anything Else? (optional)
## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
