### PR TITLE
EPP-320 new and renew -  display the units of measure

### DIFF
--- a/apps/epp-amend/fields/index.js
+++ b/apps/epp-amend/fields/index.js
@@ -325,9 +325,8 @@ module.exports = {
   'how-much-precursor': amountWithUnitSelectComponent('how-much-precursor', {
     legend: { className: 'govuk-fieldset__legend--s' },
     mixin: 'input-amount-with-unit-select',
-    amountOptional: 'false',
-    validate: helpers.amountWithUnitSelectComponentValidators,
-    parse: val => helpers.parseUnitValues(val)
+    validate: helpers.precursorAndPoisonQuantityValidators,
+    parse: val => helpers.parseHyphenatedPairValue(val)
   }),
   'what-concentration-precursor': {
     mixin: 'input-text',
@@ -423,9 +422,8 @@ module.exports = {
   'how-much-poison': amountWithUnitSelectComponent('how-much-poison', {
     legend: { className: 'govuk-fieldset__legend--s' },
     mixin: 'input-amount-with-unit-select',
-    amountOptional: 'false',
-    validate: helpers.amountWithUnitSelectComponentValidators,
-    parse: val => helpers.parseUnitValues(val)
+    validate: helpers.precursorAndPoisonQuantityValidators,
+    parse: val => helpers.parseHyphenatedPairValue(val)
   }),
   'compound-or-salt': {
     mixin: 'textarea',

--- a/apps/epp-amend/fields/index.js
+++ b/apps/epp-amend/fields/index.js
@@ -322,6 +322,13 @@ module.exports = {
     attributes: [{ attribute: 'rows', value: 5 }],
     labelClassName: 'govuk-label--s'
   },
+  'how-much-precursor': amountWithUnitSelectComponent('how-much-precursor', {
+    legend: { className: 'govuk-fieldset__legend--s' },
+    mixin: 'input-amount-with-unit-select',
+    amountOptional: 'false',
+    validate: helpers.amountWithUnitSelectComponentValidators,
+    parse: val => helpers.parseUnitValues(val)
+  }),
   'what-concentration-precursor': {
     mixin: 'input-text',
     validate: [
@@ -413,6 +420,13 @@ module.exports = {
     attributes: [{ attribute: 'rows', value: 5 }],
     labelClassName: 'govuk-label--s'
   },
+  'how-much-poison': amountWithUnitSelectComponent('how-much-poison', {
+    legend: { className: 'govuk-fieldset__legend--s' },
+    mixin: 'input-amount-with-unit-select',
+    amountOptional: 'false',
+    validate: helpers.amountWithUnitSelectComponentValidators,
+    parse: val => helpers.parseUnitValues(val)
+  }),
   'compound-or-salt': {
     mixin: 'textarea',
     validate: ['required', 'notUrl', helpers.textAreaDefaultLength],
@@ -654,29 +668,5 @@ module.exports = {
   'amend-declaration': {
     mixin: 'checkbox',
     validate: ['required']
-  },
-  'how-much-precursor': amountWithUnitSelectComponent('how-much-precursor', {
-    legend: { className: 'govuk-fieldset__legend--s' },
-    mixin: 'input-amount-with-unit-select',
-    amountOptional: 'false',
-    validate: ['required',
-      { type: 'regex', arguments: /^[\d]*\.?\d+$/ },
-      { type: 'max', arguments: 999999 },
-      { type: 'min', arguments: 0.01 }
-    ],
-    parse: val => val ?
-      (val.substring(0, val.lastIndexOf('-')) || '0') + ' ' +  val.substring(val.lastIndexOf('-') + 1) : ''
-  }),
-  'how-much-poison': amountWithUnitSelectComponent('how-much-poison', {
-    legend: { className: 'govuk-fieldset__legend--s' },
-    mixin: 'input-amount-with-unit-select',
-    amountOptional: 'false',
-    validate: ['required',
-      { type: 'regex', arguments: /^[\d]*\.?\d+$/ },
-      { type: 'max', arguments: 999999 },
-      { type: 'min', arguments: 0.01 }
-    ],
-    parse: val => val ?
-      (val.substring(0, val.lastIndexOf('-')) || '0') + ' ' +  val.substring(val.lastIndexOf('-') + 1) : ''
-  })
+  }
 };

--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -8,8 +8,8 @@ const {
   isValidUkDrivingLicenceNumber,
   isValidConcentrationValue,
   textAreaDefaultLength,
-  parseUnitValues,
-  amountWithUnitSelectComponentValidators
+  parseHyphenatedPairValue,
+  precursorAndPoisonQuantityValidators
 } = require('../../../utilities/helpers');
 const countersignatoryYears = require('../../../utilities/constants/countersignatory-years');
 const precursorList = require('../../../utilities/constants/explosive-precursors');
@@ -781,9 +781,8 @@ module.exports = {
   'how-much-precursor': amountWithUnitSelectComponent('how-much-precursor', {
     legend: { className: 'govuk-fieldset__legend--s' },
     mixin: 'input-amount-with-unit-select',
-    amountOptional: 'false',
-    validate: amountWithUnitSelectComponentValidators,
-    parse: val => parseUnitValues(val)
+    validate: precursorAndPoisonQuantityValidators,
+    parse: val => parseHyphenatedPairValue(val)
   }),
   'compound-or-salt': {
     mixin: 'textarea',
@@ -873,9 +872,8 @@ module.exports = {
   'how-much-poison': amountWithUnitSelectComponent('how-much-poison', {
     legend: { className: 'govuk-fieldset__legend--s' },
     mixin: 'input-amount-with-unit-select',
-    amountOptional: 'false',
-    validate: amountWithUnitSelectComponentValidators,
-    parse: val => parseUnitValues(val)
+    validate: precursorAndPoisonQuantityValidators,
+    parse: val => parseHyphenatedPairValue(val)
   }),
   'what-concentration-precursor': {
     mixin: 'input-text',

--- a/apps/epp-new/fields/index.js
+++ b/apps/epp-new/fields/index.js
@@ -1,4 +1,5 @@
 const dateComponent = require('hof').components.date;
+const amountWithUnitSelectComponent = require('hof').components.amountWithUnitSelect;
 const titles = require('../../../utilities/constants/titles');
 const countries = require('../../../utilities/constants/countries');
 const {
@@ -6,11 +7,14 @@ const {
   validInternationalPhoneNumber,
   isValidUkDrivingLicenceNumber,
   isValidConcentrationValue,
-  textAreaDefaultLength
+  textAreaDefaultLength,
+  parseUnitValues,
+  amountWithUnitSelectComponentValidators
 } = require('../../../utilities/helpers');
 const countersignatoryYears = require('../../../utilities/constants/countersignatory-years');
 const precursorList = require('../../../utilities/constants/explosive-precursors');
 const poisonsList = require('../../../utilities/constants/poisons.js');
+
 
 module.exports = {
   'new-renew-title': {
@@ -774,12 +778,13 @@ module.exports = {
     attributes: [{ attribute: 'rows', value: 5 }],
     labelClassName: 'govuk-label--s'
   },
-  'how-much-poison': {
-    mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
-    className: ['govuk-input', 'govuk-input--width-10'],
-    labelClassName: 'govuk-label--s'
-  },
+  'how-much-precursor': amountWithUnitSelectComponent('how-much-precursor', {
+    legend: { className: 'govuk-fieldset__legend--s' },
+    mixin: 'input-amount-with-unit-select',
+    amountOptional: 'false',
+    validate: amountWithUnitSelectComponentValidators,
+    parse: val => parseUnitValues(val)
+  }),
   'compound-or-salt': {
     mixin: 'textarea',
     validate: ['required', 'notUrl', textAreaDefaultLength],
@@ -865,12 +870,13 @@ module.exports = {
     attributes: [{ attribute: 'rows', value: 5 }],
     labelClassName: 'govuk-label--s'
   },
-  'how-much-precursor': {
-    mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
-    className: ['govuk-input', 'govuk-input--width-10'],
-    labelClassName: 'govuk-label--s'
-  },
+  'how-much-poison': amountWithUnitSelectComponent('how-much-poison', {
+    legend: { className: 'govuk-fieldset__legend--s' },
+    mixin: 'input-amount-with-unit-select',
+    amountOptional: 'false',
+    validate: amountWithUnitSelectComponentValidators,
+    parse: val => parseUnitValues(val)
+  }),
   'what-concentration-precursor': {
     mixin: 'input-text',
     validate: [

--- a/apps/epp-new/index.js
+++ b/apps/epp-new/index.js
@@ -31,6 +31,7 @@ const RenderPoisonDetails = require('../epp-common/behaviours/render-poison-deta
 const RenderPrecursorDetails = require('../epp-common/behaviours/render-precursors-detail');
 const AggregateSaveEditPrecursorPoison = require('../epp-common/behaviours/aggregator-save-update-precursors-poisons');
 const ParseSummaryPrecursorsPoisons = require('../epp-common/behaviours/parse-summary-precursors-poisons');
+const ExecuteFieldCustomParse = require('../epp-common/behaviours/execute-field-custom-parse');
 const ModifySummaryChangeLink = require('../epp-common/behaviours/modify-summary-change-links');
 const preventDuplicateSelection = require('../epp-common/behaviours/prevent-duplicate-selection');
 const { disallowIndexing } = require('../../config');
@@ -627,6 +628,7 @@ module.exports = {
     '/precursors-summary': {
       behaviours: [
         AggregateSaveEditPrecursorPoison,
+        ExecuteFieldCustomParse,
         ParseSummaryPrecursorsPoisons,
         EditRouteReturn
       ],
@@ -638,6 +640,10 @@ module.exports = {
         'what-concentration-precursor',
         'where-to-store-precursor',
         'where-to-use-precursor'
+      ],
+      additionalFieldsToClear: [
+        'how-much-precursor-amount',
+        'how-much-precursor-unit'
       ],
       titleField: ['precursor-field'],
       addStep: 'select-precursor',
@@ -718,6 +724,7 @@ module.exports = {
     '/poison-summary': {
       behaviours: [
         AggregateSaveEditPrecursorPoison,
+        ExecuteFieldCustomParse,
         ParseSummaryPrecursorsPoisons,
         EditRouteReturn
       ],
@@ -730,6 +737,10 @@ module.exports = {
         'what-concentration-poison',
         'where-to-store-poison',
         'where-to-use-poison'
+      ],
+      additionalFieldsToClear: [
+        'how-much-poison-amount',
+        'how-much-poison-unit'
       ],
       titleField: ['poison-field'],
       addStep: 'select-poisons',

--- a/apps/epp-new/translations/src/en/fields.json
+++ b/apps/epp-new/translations/src/en/fields.json
@@ -372,9 +372,16 @@
     "summary-heading": "Why do you need it?"
   },
   "how-much-precursor":{
-    "label": "How much do you wish to acquire at any one time within a 6-month period?",
-    "hint": "Enter the amount and the unit. For example, 10 litres",
-    "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
+    "legend": "How much do you wish to acquire at any one time within a 6-month period?",
+    "hint": "Enter an amount and select the relevant unit",
+    "summary-heading": "How much",
+    "options": [
+      { "null": "Select a unit" },
+      { "label": "Grams", "value": "grams" },
+      { "label": "Kilograms", "value": "kilograms" },
+      { "label": "Litres", "value": "litres" },
+      { "label": "Millilitres", "value": "millilitres" }
+    ]
   },
   "what-concentration-precursor":{
     "label": "What concentration % w/w of the substance do you need?",
@@ -439,9 +446,16 @@
     "summary-heading": "Why do you need it?"
   },
   "how-much-poison":{
-    "label": "How much do you wish to acquire at any one time within a 6-month period?",
-    "hint": "Enter the amount and the unit. For example, 10 litres",
-    "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
+    "legend": "How much do you wish to acquire at any one time within a 6-month period?",
+    "hint": "Enter an amount and select the relevant unit",
+    "summary-heading": "How much",
+    "options": [
+      { "null": "Select a unit" },
+      { "label": "Grams", "value": "grams" },
+      { "label": "Kilograms", "value": "kilograms" },
+      { "label": "Litres", "value": "litres" },
+      { "label": "Millilitres", "value": "millilitres" }
+    ]
   },
   "compound-or-salt": {
     "label": "Specific compound or salt",

--- a/apps/epp-new/translations/src/en/validation.json
+++ b/apps/epp-new/translations/src/en/validation.json
@@ -37,9 +37,17 @@
     "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
   "how-much-poison": {
-    "required": "Enter how much of poison you wish to acquire at any one time",
-    "maxlength": "Quantity of the explosive precursor you wish to acquire must be 250 characters or less",
-    "notUrl": "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+    "default": "Enter a valid amount and unit",
+    "required": "Enter the amount of poison you wish to buy"
+  },
+  "how-much-poison-amount": {
+    "required": "Enter the amount of poison you wish to buy",
+    "regex": "Amount you wish to buy must only include numbers",
+    "max": "Amount you wish to buy must be 999,999 or less",
+    "min": "Amount you wish to buy must be 0.01 or more"
+  },
+  "how-much-poison-unit": {
+    "required": "Select the unit you wish to buy the poison in"
   },
   "compound-or-salt": {
     "required": "Enter the specific compound or salt",
@@ -422,9 +430,17 @@
     "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
   "how-much-precursor": {
-    "required": "Enter how much of the explosive precursor you wish to acquire at any one time",
-    "maxlength": "Quantity of the explosive precursor you wish to acquire must be 250 characters or less",
-    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+    "default": "Enter a valid amount and unit",
+    "required": "Enter how much of the explosive precursor you wish to acquire at any one time"
+  },
+  "how-much-precursor-amount": {
+    "required": "Enter the amount of explosive precursor you wish to buy",
+    "regex": "Amount you wish to buy must only include numbers",
+    "max": "Amount you wish to buy must be 999,999 or less",
+    "min": "Amount you wish to buy must be 0.01 or more"
+  },
+  "how-much-precursor-unit": {
+    "required": "Select the unit you wish to buy the explosive precursor in"
   },
   "where-to-store-precursor": {
     "required": "Select where you will store the explosive precursor"

--- a/test/unit/utilities/utilities.spec.js
+++ b/test/unit/utilities/utilities.spec.js
@@ -16,7 +16,7 @@ const {
   displayOptionalField,
   formatAttachments,
   showCounterSignatoryDetails,
-  parseUnitValues
+  parseHyphenatedPairValue
 } = require('../../../utilities/helpers');
 
 const explosivePrecursorsList = require('../../../utilities/constants/explosive-precursors');
@@ -580,27 +580,27 @@ describe('EPP utilities tests', () => {
     });
   });
 
-  describe('parseUnitValues tests', () => {
+  describe('parseHyphenatedPairValue tests', () => {
     it('should return empty string for falsy inputs', () => {
       const inputs = [null, undefined, ''];
-      inputs.forEach(input => expect(parseUnitValues(input)).to.equal(''));
+      inputs.forEach(input => expect(parseHyphenatedPairValue(input)).to.equal(''));
     });
 
     it('should format value-unit when hyphen present', () => {
-      expect(parseUnitValues('100-g')).to.equal('100 g');
-      expect(parseUnitValues('250-ml')).to.equal('250 ml');
+      expect(parseHyphenatedPairValue('100-g')).to.equal('100 g');
+      expect(parseHyphenatedPairValue('250-ml')).to.equal('250 ml');
     });
 
     it('should default value to 0 when missing before last hyphen', () => {
-      expect(parseUnitValues('-ml')).to.equal('0 ml');
+      expect(parseHyphenatedPairValue('-ml')).to.equal('0 ml');
     });
 
     it('should treat input without hyphen as unit (value becomes 0)', () => {
-      expect(parseUnitValues('100ml')).to.equal('0 100ml');
+      expect(parseHyphenatedPairValue('100ml')).to.equal('0 100ml');
     });
 
     it('should handle trailing hyphen (empty unit)', () => {
-      expect(parseUnitValues('g-')).to.equal('g ');
+      expect(parseHyphenatedPairValue('g-')).to.equal('g ');
     });
   });
 });

--- a/test/unit/utilities/utilities.spec.js
+++ b/test/unit/utilities/utilities.spec.js
@@ -15,7 +15,8 @@ const {
   isLicenceValid,
   displayOptionalField,
   formatAttachments,
-  showCounterSignatoryDetails
+  showCounterSignatoryDetails,
+  parseUnitValues
 } = require('../../../utilities/helpers');
 
 const explosivePrecursorsList = require('../../../utilities/constants/explosive-precursors');
@@ -517,7 +518,9 @@ describe('EPP utilities tests', () => {
       const req = { sessionModel: { get: sinon.stub() } };
       req.sessionModel.get.withArgs('replace-is-details-changed').returns('no');
       req.sessionModel.get.withArgs('replace-name-options').returns('yes');
-      req.sessionModel.get.withArgs('replace-home-address-options').returns('yes');
+      req.sessionModel.get
+        .withArgs('replace-home-address-options')
+        .returns('yes');
 
       expect(showCounterSignatoryDetails('test-value', req)).to.be.null;
     });
@@ -527,7 +530,9 @@ describe('EPP utilities tests', () => {
         .withArgs('replace-is-details-changed')
         .returns('yes');
       req.sessionModel.get.withArgs('replace-name-options').returns('no');
-      req.sessionModel.get.withArgs('replace-home-address-options').returns('no');
+      req.sessionModel.get
+        .withArgs('replace-home-address-options')
+        .returns('no');
 
       expect(showCounterSignatoryDetails('test-value', req)).to.be.null;
     });
@@ -537,7 +542,9 @@ describe('EPP utilities tests', () => {
         .withArgs('replace-is-details-changed')
         .returns('yes');
       req.sessionModel.get.withArgs('replace-name-options').returns('yes');
-      req.sessionModel.get.withArgs('replace-home-address-options').returns('no');
+      req.sessionModel.get
+        .withArgs('replace-home-address-options')
+        .returns('no');
 
       expect(showCounterSignatoryDetails('test-value', req)).to.equal(
         'test-value'
@@ -549,7 +556,9 @@ describe('EPP utilities tests', () => {
         .withArgs('replace-is-details-changed')
         .returns('yes');
       req.sessionModel.get.withArgs('replace-name-options').returns('no');
-      req.sessionModel.get.withArgs('replace-home-address-options').returns('yes');
+      req.sessionModel.get
+        .withArgs('replace-home-address-options')
+        .returns('yes');
 
       expect(showCounterSignatoryDetails('test-value', req)).to.equal(
         'test-value'
@@ -561,11 +570,37 @@ describe('EPP utilities tests', () => {
         .withArgs('replace-is-details-changed')
         .returns('yes');
       req.sessionModel.get.withArgs('replace-name-options').returns('yes');
-      req.sessionModel.get.withArgs('replace-home-address-options').returns('yes');
+      req.sessionModel.get
+        .withArgs('replace-home-address-options')
+        .returns('yes');
 
       expect(showCounterSignatoryDetails('test-value', req)).to.equal(
         'test-value'
       );
+    });
+  });
+
+  describe('parseUnitValues tests', () => {
+    it('should return empty string for falsy inputs', () => {
+      const inputs = [null, undefined, ''];
+      inputs.forEach(input => expect(parseUnitValues(input)).to.equal(''));
+    });
+
+    it('should format value-unit when hyphen present', () => {
+      expect(parseUnitValues('100-g')).to.equal('100 g');
+      expect(parseUnitValues('250-ml')).to.equal('250 ml');
+    });
+
+    it('should default value to 0 when missing before last hyphen', () => {
+      expect(parseUnitValues('-ml')).to.equal('0 ml');
+    });
+
+    it('should treat input without hyphen as unit (value becomes 0)', () => {
+      expect(parseUnitValues('100ml')).to.equal('0 100ml');
+    });
+
+    it('should handle trailing hyphen (empty unit)', () => {
+      expect(parseUnitValues('g-')).to.equal('g ');
     });
   });
 });

--- a/utilities/constants/string-constants.js
+++ b/utilities/constants/string-constants.js
@@ -30,6 +30,8 @@ const SUBSTANCES = {
   POISON: 'poison'
 };
 
+const AMOUNT_DECIMAL_REGEX = /^[\d]*\.?\d+$/;
+
 module.exports = {
   PATH_NEW_RENEW,
   PATH_AMEND,
@@ -51,5 +53,6 @@ module.exports = {
   API_METHODS,
   SUBSTANCES,
   PATH_APPLICATION_TYPE,
-  PATH_SERVICE_PROBLEM
+  PATH_SERVICE_PROBLEM,
+  AMOUNT_DECIMAL_REGEX
 };

--- a/utilities/helpers/index.js
+++ b/utilities/helpers/index.js
@@ -3,11 +3,18 @@ const validators = require('hof/controller/validation/validators');
 const explosivePrecursorsList = require('../constants/explosive-precursors');
 const poisonList = require('../constants/poisons');
 const config = require('../../config');
-const { SUBSTANCES } = require('../constants/string-constants');
+const { SUBSTANCES, AMOUNT_DECIMAL_REGEX } = require('../constants/string-constants');
 
 const DEFAULT_AGGREGATOR_LIMIT = 100;
 const TEXT_NOT_PROVIDED = 'Not provided';
 const DATE_FORMAT_YYYY_MM_DD = 'YYYY-MM-DD';
+
+const amountWithUnitSelectComponentValidators = [
+  'required',
+  { type: 'regex', arguments: AMOUNT_DECIMAL_REGEX },
+  { type: 'max', arguments: 999999 },
+  { type: 'min', arguments: 0.01 }
+];
 
 class NotifyMock {
   sendEmail() {
@@ -313,6 +320,14 @@ const showCounterSignatoryDetails = (value, req) => {
     : null;
 };
 
+const parseUnitValues = val => {
+  return val
+    ? (val.substring(0, val.lastIndexOf('-')) || '0') +
+        ' ' +
+        val.substring(val.lastIndexOf('-') + 1)
+    : '';
+};
+
 module.exports = {
   isLicenceValid,
   isApplicationType,
@@ -334,6 +349,8 @@ module.exports = {
   displayOptionalField,
   formatAttachments,
   showCounterSignatoryDetails,
+  parseUnitValues,
+  amountWithUnitSelectComponentValidators,
   NotifyClient:
     config.govukNotify.notifyApiKey === 'USE_MOCK'
       ? NotifyMock

--- a/utilities/helpers/index.js
+++ b/utilities/helpers/index.js
@@ -9,7 +9,7 @@ const DEFAULT_AGGREGATOR_LIMIT = 100;
 const TEXT_NOT_PROVIDED = 'Not provided';
 const DATE_FORMAT_YYYY_MM_DD = 'YYYY-MM-DD';
 
-const amountWithUnitSelectComponentValidators = [
+const precursorAndPoisonQuantityValidators = [
   'required',
   { type: 'regex', arguments: AMOUNT_DECIMAL_REGEX },
   { type: 'max', arguments: 999999 },
@@ -320,7 +320,7 @@ const showCounterSignatoryDetails = (value, req) => {
     : null;
 };
 
-const parseUnitValues = val => {
+const parseHyphenatedPairValue = val => {
   return val
     ? (val.substring(0, val.lastIndexOf('-')) || '0') +
         ' ' +
@@ -349,8 +349,8 @@ module.exports = {
   displayOptionalField,
   formatAttachments,
   showCounterSignatoryDetails,
-  parseUnitValues,
-  amountWithUnitSelectComponentValidators,
+  parseHyphenatedPairValue,
+  precursorAndPoisonQuantityValidators,
   NotifyClient:
     config.govukNotify.notifyApiKey === 'USE_MOCK'
       ? NotifyMock


### PR DESCRIPTION
## What? 
> https://collaboration.homeoffice.gov.uk/jira/browse/EPP-320 - New & Renew: Display the units of measure for precursors and poisons details pages
## Why? 
## How? 

Add unit of measure component to the /precursor-details and /poison-details pages

common changes are already completed here - https://github.com/UKHomeOffice/explosives-precursors-poisons/pull/203

- Refactor some of the common code for reusability 

## Testing?
## Screenshots (optional)
<img width="1284" height="1685" alt="epp-epp-320 internal branch sas-notprod homeoffice gov uk_new-renew_precursor-details" src="https://github.com/user-attachments/assets/6e18972c-6965-49f0-9900-75a624681097" />

## Anything Else? (optional)
## Check list


- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
