### PR TITLE
EPP-365: Replace: Display the units of measure for precursors and poisons details pages

### DIFF
--- a/apps/epp-replace/fields/index.js
+++ b/apps/epp-replace/fields/index.js
@@ -1,12 +1,15 @@
 const titles = require('../../../utilities/constants/titles');
 const dateComponent = require('hof').components.date;
+const amountWithUnitSelectComponent = require('hof').components.amountWithUnitSelect;
 const poisonsList = require('../../../utilities/constants/poisons.js');
 const countersignatoryYears = require('../../../utilities/constants/countersignatory-years.js');
 const {
   isValidUkDrivingLicenceNumber,
   validInternationalPhoneNumber,
   textAreaDefaultLength,
-  isValidConcentrationValue
+  isValidConcentrationValue,
+  parseHyphenatedPairValue,
+  precursorAndPoisonQuantityValidators
 } = require('../../../utilities/helpers');
 const countries = require('../../../utilities/constants/countries');
 const policeForces = require('../../../utilities/constants/police-forces.js');
@@ -427,12 +430,12 @@ module.exports = {
     attributes: [{ attribute: 'rows', value: 5 }],
     labelClassName: 'govuk-label--s'
   },
-  'how-much-poison': {
-    mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
-    className: ['govuk-input', 'govuk-input--width-10'],
-    labelClassName: 'govuk-label--s'
-  },
+  'how-much-poison': amountWithUnitSelectComponent('how-much-poison', {
+    legend: { className: 'govuk-fieldset__legend--s' },
+    mixin: 'input-amount-with-unit-select',
+    validate: precursorAndPoisonQuantityValidators,
+    parse: val => parseHyphenatedPairValue(val)
+  }),
   'compound-or-salt': {
     mixin: 'textarea',
     validate: ['required', 'notUrl', textAreaDefaultLength],
@@ -634,12 +637,12 @@ module.exports = {
     attributes: [{ attribute: 'rows', value: 5 }],
     labelClassName: 'govuk-label--s'
   },
-  'how-much-precursor': {
-    mixin: 'input-text',
-    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 250 }],
-    className: ['govuk-input', 'govuk-input--width-10'],
-    labelClassName: 'govuk-label--s'
-  },
+  'how-much-precursor': amountWithUnitSelectComponent('how-much-precursor', {
+    legend: { className: 'govuk-fieldset__legend--s' },
+    mixin: 'input-amount-with-unit-select',
+    validate: precursorAndPoisonQuantityValidators,
+    parse: val => parseHyphenatedPairValue(val)
+  }),
   'what-concentration-precursor': {
     mixin: 'input-text',
     validate: [

--- a/apps/epp-replace/index.js
+++ b/apps/epp-replace/index.js
@@ -28,6 +28,8 @@ const NoPrecursorsPoisonsNavigation = require('./behaviours/no-precursors-poison
 const NoSubstanceChangeNavigation = require('./behaviours/no-substance-change-navigation');
 const DeleteRedundantDocuments = require('../epp-common/behaviours/delete-redundant-documents');
 const preventDuplicateSelection = require('../epp-common/behaviours/prevent-duplicate-selection');
+const ExecuteFieldCustomParse = require('../epp-common/behaviours/execute-field-custom-parse');
+
 const { disallowIndexing } = require('../../config');
 
 const pages = {};
@@ -456,6 +458,7 @@ module.exports = {
     '/precursors-summary': {
       behaviours: [
         AggregateSaveEditPrecursorPoison,
+        ExecuteFieldCustomParse,
         ParseSummaryPrecursorsPoisons,
         EditRouteReturn
       ],
@@ -467,6 +470,10 @@ module.exports = {
         'what-concentration-precursor',
         'where-to-store-precursor',
         'where-to-use-precursor'
+      ],
+      additionalFieldsToClear: [
+        'how-much-precursor-amount',
+        'how-much-precursor-unit'
       ],
       titleField: ['precursor-field'],
       addStep: 'select-precursor',
@@ -527,6 +534,7 @@ module.exports = {
       behaviours: [
         CounterSignatoryNavigation('/poison-summary'),
         AggregateSaveEditPrecursorPoison,
+        ExecuteFieldCustomParse,
         ParseSummaryPrecursorsPoisons,
         EditRouteReturn
       ],
@@ -539,6 +547,10 @@ module.exports = {
         'what-concentration-poison',
         'where-to-store-poison',
         'where-to-use-poison'
+      ],
+      additionalFieldsToClear: [
+        'how-much-poison-amount',
+        'how-much-poison-unit'
       ],
       titleField: ['poison-field'],
       addStep: 'select-poisons',

--- a/apps/epp-replace/translations/src/en/fields.json
+++ b/apps/epp-replace/translations/src/en/fields.json
@@ -233,9 +233,16 @@
   "summary-heading": "Why do you need it?"
 },
 "how-much-precursor": {
-  "label": "How much do you wish to acquire at any one time within a 6-month period?",
-  "hint": "Enter the amount and the unit. For example, 10 litres",
-  "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
+  "legend": "How much do you wish to acquire at any one time within a 6-month period?",
+  "hint": "Enter an amount and select the relevant unit",
+  "summary-heading": "How much",
+  "options": [
+    { "null": "Select a unit" },
+    { "label": "Grams", "value": "grams" },
+    { "label": "Kilograms", "value": "kilograms" },
+    { "label": "Litres", "value": "litres" },
+    { "label": "Millilitres", "value": "millilitres" }
+  ]
 },
 "what-concentration-precursor": {
   "label": "What concentration % w/w of the substance do you need?",
@@ -300,9 +307,16 @@
     "summary-heading": "Why do you need it?"
   },
   "how-much-poison": {
-    "label": "How much do you wish to acquire at any one time within a 6-month period?",
-    "hint": "Enter the amount and the unit. For example, 10 litres",
-    "summary-heading": "How much do you wish to acquire at any one time within a 6-month period?"
+    "legend": "How much do you wish to acquire at any one time within a 6-month period?",
+    "hint": "Enter an amount and select the relevant unit",
+    "summary-heading": "How much",
+    "options": [
+      { "null": "Select a unit" },
+      { "label": "Grams", "value": "grams" },
+      { "label": "Kilograms", "value": "kilograms" },
+      { "label": "Litres", "value": "litres" },
+      { "label": "Millilitres", "value": "millilitres" }
+    ]
   },
   "compound-or-salt": {
     "label": "Specific compound or salt",

--- a/apps/epp-replace/translations/src/en/validation.json
+++ b/apps/epp-replace/translations/src/en/validation.json
@@ -41,9 +41,17 @@
     "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
   "how-much-poison": {
-    "required": "Enter how much of poison you wish to acquire at any one time",
-    "maxlength": "Quantity of the explosive precursor you wish to acquire must be 250 characters or less",
-    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+    "default": "Enter a valid amount and unit",
+    "required": "Enter the amount of poison you wish to buy"
+  },
+  "how-much-poison-amount": {
+    "required": "Enter the amount of poison you wish to buy",
+    "regex": "Amount you wish to buy must only include numbers",
+    "max": "Amount you wish to buy must be 999,999 or less",
+    "min": "Amount you wish to buy must be 0.01 or more"
+  },
+  "how-much-poison-unit": {
+    "required": "Select the unit you wish to buy the poison in"
   },
   "compound-or-salt": {
      "required": "Enter the specific compound or salt",
@@ -317,9 +325,17 @@
     "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
   },
   "how-much-precursor": {
-    "required": "Enter how much of the explosive precursor you wish to acquire at any one time",
-    "maxlength": "Quantity of the explosive precursor you wish to acquire must be 250 characters or less",
-    "notUrl" : "Answer must not contain a URL. Remove any links, URLs or special characters like /@:%_+~#=\\ from your answer"
+    "default": "Enter a valid amount and unit",
+    "required": "Enter how much of the explosive precursor you wish to acquire at any one time"
+  },
+  "how-much-precursor-amount": {
+    "required": "Enter the amount of explosive precursor you wish to buy",
+    "regex": "Amount you wish to buy must only include numbers",
+    "max": "Amount you wish to buy must be 999,999 or less",
+    "min": "Amount you wish to buy must be 0.01 or more"
+  },
+  "how-much-precursor-unit": {
+    "required": "Select the unit you wish to buy the explosive precursor in"
   },
   "where-to-store-precursor": {
     "required": "Select where you will store the explosive precursor"

--- a/utilities/helpers/index.js
+++ b/utilities/helpers/index.js
@@ -341,8 +341,6 @@ module.exports = {
   DEFAULT_AGGREGATOR_LIMIT,
   TEXT_NOT_PROVIDED,
   DATE_FORMAT_YYYY_MM_DD,
-  parseHyphenatedPairValue,
-  precursorAndPoisonQuantityValidators,
   getFormattedDate,
   isEditMode,
   getSubstanceShortLabel,

--- a/utilities/helpers/index.js
+++ b/utilities/helpers/index.js
@@ -341,6 +341,8 @@ module.exports = {
   DEFAULT_AGGREGATOR_LIMIT,
   TEXT_NOT_PROVIDED,
   DATE_FORMAT_YYYY_MM_DD,
+  parseHyphenatedPairValue,
+  precursorAndPoisonQuantityValidators,
   getFormattedDate,
   isEditMode,
   getSubstanceShortLabel,


### PR DESCRIPTION
## What? 
[Replace: Display the units of measure for precursors and poisons](https://collaboration.homeoffice.gov.uk/jira/browse/EPP-365)

## Why? 
To implement unit of measure component (amountWithUnitSelect) on the /precursor-details and /poison-details pages (replacing the amount text box for 'how-much-precusor'/'how-much-poison' with the new hof component)

## How? 
- Adds unit of measure component (amountWithUnitSelect) in places of 'how-much-precursor' and 'how-much-poison' text boxes within the 'replace' flow
- Adds validation, validation errors and parsing logic
- Configures page to clear inputs once submitted

## Testing?
- Unit tests ran
- Code linited
- Manually tested

## Screenshots  (optional)
<img width="416" height="93" alt="Screenshot 2026-02-13 at 08 31 12" src="https://github.com/user-attachments/assets/319058bd-c9eb-45ce-b749-02c776ca0e8c" />

## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
